### PR TITLE
Update line number logic for expected ')' error

### DIFF
--- a/helpers/clang.py
+++ b/helpers/clang.py
@@ -116,7 +116,7 @@ def help(lines):
             "Make sure that all opening parentheses `(` are matched with a closing parenthesis `)` in {}.".format(matches.group(1)),
             "In particular, check to see if you are missing a closing parenthesis on line {} of {}.".format(match_line, matches.group(1))
         ]
-        return (lines[0:1], after)
+        return (before, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':

--- a/helpers/clang.py
+++ b/helpers/clang.py
@@ -101,9 +101,20 @@ def help(lines):
     # ^
     matches = re.search(r"^([^:]+):(\d+):\d+: error: expected '\)'", lines[0])
     if matches:
+        # assume that the line number for the matching ')' is the line that generated the error
+        match_line = matches.group(2)
+        before = lines[0:1]
+        
+        # if there's a note on which '(' to match, use that line number instead
+        if (len(lines) >= 4):
+            parens_match = re.search(r"^([^:]+):(\d+):\d+: note: to match this '\('", lines[3])
+            if parens_match:
+                match_line = parens_match.group(2)
+                before = lines[0:4]
+                
         after = [
             "Make sure that all opening parentheses `(` are matched with a closing parenthesis `)` in {}.".format(matches.group(1)),
-            "In particular, check to see if you are missing a closing parenthesis on line {} of {}.".format(matches.group(2), matches.group(1))
+            "In particular, check to see if you are missing a closing parenthesis on line {} of {}.".format(match_line, matches.group(1))
         ]
         return (lines[0:1], after)
 


### PR DESCRIPTION
Just making an improvement to the `error: expected ')'` matcher. Right now it works fine for catching errors where the parentheses are missing for a singular statement, e.g. `printf("hello, world!";`.

However, I noticed that for code like:

```
 1  #include <stdio.h>
 2
 3  int main(void)
 4  {
 5      int x = 28;
 6      if(x == 28
 7      {
 8          printf("x is 28!");
 9      }
10  }
```

we get the following error output:

```
foo.c:7:5: error: expected ')'
    {
    ^
foo.c:6:7: note: to match this '('
    if(x == 28
      ^
```

which yields the `help50` message:

```
Make sure that all opening parentheses `(` are matched with a closing parenthesis `)` in foo.c.
In particular, check to see if you are missing a closing parenthesis on line 7 of foo.c.
```

But the parentheses should really be added to line `6` instead of `7` (the line number of the `note` rather than the `error`). This updated matcher checks to see if there's a `note`, and if so, proposes that line number instead.