### PR TITLE
successful compile message for make

### DIFF
--- a/helpers/make.py
+++ b/helpers/make.py
@@ -29,3 +29,12 @@ def help(lines):
             "Try compiling your program with `make {}` rather than `make {}.c`.".format(matches.group(1), matches.group(1))
         ]
         return (lines[0:1], after)
+    
+    # $ make foo.c
+    # clang -ggdb3 -O0 -std=c11 -Wall -Werror -Wshadow foo.c -lcs50 -lm -o foo
+    matches = re.search(r"^clang", lines[0])
+    if matches and len(lines) == 1 and "error:" not in lines[0]:
+        after = [
+            "Looks like your program compiles successfully!"
+        ]
+        return (lines[0:1], after)


### PR DESCRIPTION
Cases like input `10` and `15` on `/review`, seem to be the result of a situation where someone ran `help50` on a program that compiles successfully. In that case, right now `help50` gives a `Sorry!` message. This update, which checks to see if the `script` is just a one-line `clang` message, handles that case.