### PR TITLE
match 'expected parameter declarator'

### DIFF
--- a/helpers/clang.py
+++ b/helpers/clang.py
@@ -92,8 +92,8 @@ def help(lines):
     matches = re.search(r"^([^:]+):(\d+):\d+: error: expected parameter declarator", lines[0])
     if matches:
         after = [
-            "If you're trying to call a function on line {} of `{}`, be sure that it's being called inside of curly braces within a function. Also check that the function's header (the line introducing the function's name) doesn't end in a semicolon.".format(matches.group(2), matches.group(1)),
-            "Alternatively, if you're trying to define a function or prototype on line {} of `{}`, be sure each argument to the function is formatted as a data type followed by a variable name.".format(matches.group(2), matches.group(1))
+            "If you're trying to call a function on line {} of `{}`, be sure that you're calling it inside of curly braces within a function. Also check that the function's header (the line introducing the function's name) doesn't end in a semicolon.".format(matches.group(2), matches.group(1)),
+            "Alternatively, if you're trying to declare a function or prototype on line {} of `{}`, be sure each argument to the function is formatted as a data type followed by a variable name.".format(matches.group(2), matches.group(1))
         ]
         return (lines[0:1], after)
 

--- a/helpers/clang.py
+++ b/helpers/clang.py
@@ -83,7 +83,20 @@ def help(lines):
             "Also check to make sure that all of the code for your function is inside of curly braces."
         ]
         return (lines[0:1], after)
-    
+
+    # $ clang foo.c
+    # /tmp/foo-1ce1b9.o: In function `main':
+    # foo.c:3:12: error: expected parameter declarator
+    # int square(28);
+    #            ^
+    matches = re.search(r"^([^:]+):(\d+):\d+: error: expected parameter declarator", lines[0])
+    if matches:
+        after = [
+            "If you're trying to call a function on line {} of `{}`, be sure that it's being called inside of curly braces within a function. Also check that the function's header (the line introducing the function's name) doesn't end in a semicolon.".format(matches.group(2), matches.group(1)),
+            "Alternatively, if you're trying to define a function or prototype on line {} of `{}`, be sure each argument to the function is formatted as a data type followed by a variable name.".format(matches.group(2), matches.group(1))
+        ]
+        return (lines[0:1], after)
+
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
     # foo.c:9:2: error: expected '}'


### PR DESCRIPTION
There are two main ways I've seen to generate the `expected parameter declarator` error. Either the user has code like the example in Issue #23 with `main(void);` followed by code not embraced in curly braces, or the user has a function or prototype with a value in the parentheses. For instance, a prototype like:

```
int square(28);
```

generates the same error. There's no good way for us to tell which case caused it, so this output just provides explanations for both scenarios.