### PR TITLE
preventing user from running help50 sans pipe and sans argv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MAINTAINER = "CS50 <sysadmins@cs50.harvard.edu>"
 NAME = help50
-VERSION = 1.0.3
+VERSION = 1.1.0
 
 .PHONY: bash
 bash:

--- a/opt/cs50/help50/bin/help50
+++ b/opt/cs50/help50/bin/help50
@@ -3,7 +3,12 @@
 # input via stdin
 # http://stackoverflow.com/a/18766794/5156190
 if [ $# -eq 0 ]; then
-    script=$(cat)
+    if [ -t 0 ]; then
+        echo "Careful, you forgot to tell me with which command you need help!"
+        exit 1
+    else
+        script=$(cat)
+    fi
 
 # input via cmd
 # http://stackoverflow.com/a/12451419/5156190


### PR DESCRIPTION
@glennholloway, any concerns with this change? Realized that usage is confusing if student accidentally runs just `help50` sans arguments (and sans pipe). So this effectively disables that interactive feature (which seems unnecessary for this type of program).

CC @brianyu28 