### PR TITLE
add matcher for semicolon after do/while

### DIFF
--- a/helpers/clang.py
+++ b/helpers/clang.py
@@ -158,9 +158,9 @@ def help(lines):
     #    printf("hello, world!")
     #                           ^
     #                           ;
-    matches = re.search(r"^[^:]+:(\d+):\d+: error: expected ';' (?:after\sexpression|at\send\sof\sdeclaration)", lines[0])
+    matches = re.search(r"^([^:]+):(\d+):\d+: error: expected ';' (?:after\sexpression|at\send\sof\sdeclaration|after\sdo\/while\sstatement)", lines[0])
     if matches:
-        after = ["Try including a semicolon at the end of line {}.".format(matches.group(1))]
+        after = ["Try including a semicolon at the end of line {} of `{}`.".format(matches.group(2), matches.group(1))]
         return (lines[0:1], after)
 
     # $ clang foo.c

--- a/helpers/clang.py
+++ b/helpers/clang.py
@@ -158,7 +158,7 @@ def help(lines):
     #    printf("hello, world!")
     #                           ^
     #                           ;
-    matches = re.search(r"^([^:]+):(\d+):\d+: error: expected ';' (?:after\sexpression|at\send\sof\sdeclaration|after\sdo\/while\sstatement)", lines[0])
+    matches = re.search(r"^([^:]+):(\d+):\d+: error: expected ';' (?:after expression|at end of declaration|after do\/while statement)", lines[0])
     if matches:
         after = ["Try including a semicolon at the end of line {} of `{}`.".format(matches.group(2), matches.group(1))]
         return (lines[0:1], after)


### PR DESCRIPTION
The `expected ';' after do/while statement` has come up 11 times in `/review` (from a common error in `mario.c` and `water.c`), so I updated the existing missing semicolon matcher to handle this case.