### PR TITLE
Show a subset of input with output

### DIFF
--- a/application.py
+++ b/application.py
@@ -54,7 +54,7 @@ def index():
                 if help:
                     after = "\n".join(help[1])
                     model.log(request.form.get("cmd"), request.form.get("username"), request.form.get("script"), after)
-                    return render_template("helpful." + format, before="\n".join(help[0]), after=after)
+                    return render_template("helpful." + format, before="\n".join(lines[:i+help[0]]), after=after)
 
         # unhelpful response
         model.log(request.form.get("cmd"), request.form.get("username"), request.form.get("script"), None)

--- a/application.py
+++ b/application.py
@@ -53,7 +53,7 @@ def index():
                 # helpful response
                 if help:
                     n, response = help
-                    response = "\n".join(response)
+                    response = " ".join(response)
                     model.log(request.form.get("cmd"), request.form.get("username"), request.form.get("script"), response)
                     return render_template("helpful." + format, before="\n".join(lines[:i+n]), after=response)
 

--- a/application.py
+++ b/application.py
@@ -52,9 +52,10 @@ def index():
 
                 # helpful response
                 if help:
-                    after = "\n".join(help[1])
-                    model.log(request.form.get("cmd"), request.form.get("username"), request.form.get("script"), after)
-                    return render_template("helpful." + format, before="\n".join(lines[:i+help[0]]), after=after)
+                    n, response = help
+                    response = "\n".join(response)
+                    model.log(request.form.get("cmd"), request.form.get("username"), request.form.get("script"), response)
+                    return render_template("helpful." + format, before="\n".join(lines[:i+n]), after=response)
 
         # unhelpful response
         model.log(request.form.get("cmd"), request.form.get("username"), request.form.get("script"), None)

--- a/helpers/bash.py
+++ b/helpers/bash.py
@@ -17,7 +17,7 @@ def help(lines):
     matches = re.search(r"^bash: (.+): No such file or directory", lines[0])
     if matches:
         response = [
-            "Are you sure `{}` exists".format(matches.group(1)),
+            "Are you sure `{}` exists?".format(matches.group(1)),
             "Did you misspell `{}`?".format(matches.group(1))
         ]
         return (1, response)

--- a/helpers/bash.py
+++ b/helpers/bash.py
@@ -5,38 +5,38 @@ def help(lines):
     # bash: foo: command not found
     matches = re.search(r"^bash: (.+): command not found", lines[0])
     if matches:
-        after = [
+        response = [
             "Are you sure `{}` exists?".format(matches.group(1)),
             "Did you misspell `{}`?".format(matches.group(1)),
             "Did you mean to execute `./{}`?".format(matches.group(1))
         ]
-        return (1, after)
+        return (1, response)
 
     # $ cd foo
     # bash: cd: foo: No such file or directory
     matches = re.search(r"^bash: (.+): No such file or directory", lines[0])
     if matches:
-        after = [
+        response = [
             "Are you sure `{}` exists".format(matches.group(1)),
             "Did you misspell `{}`?".format(matches.group(1))
         ]
-        return (1, after)
+        return (1, response)
 
     # $ ./foo
     # bash: ./foo: Permission denied
     matches = re.search(r"^bash: .*?(([^/]+)\.([^/.]+)): Permission denied", lines[0])
     if matches:
-        after = [
+        response = [
             "`{}` couldn't be executed.".format(matches.group(1))
         ]
         if (matches.group(3) == "c"):
-            after.append("Did you mean to execute `./{}`?".format(matches.group(2)))
+            response.append("Did you mean to execute `./{}`?".format(matches.group(2)))
         elif (matches.group(3) == "pl"):
-            after.append("Did you mean to execute `perl {}`?".format(matches.group(1)))
+            response.append("Did you mean to execute `perl {}`?".format(matches.group(1)))
         elif (matches.group(3) == "php"):
-            after.append("Did you mean to execute `php {}`?".format(matches.group(1)))
+            response.append("Did you mean to execute `php {}`?".format(matches.group(1)))
         elif (matches.group(3) == "rb"):
-            after.append("Did you mean to execute `ruby {}`?".format(matches.group(1)))
+            response.append("Did you mean to execute `ruby {}`?".format(matches.group(1)))
         else:
-            after.append("Did you remember to make `{}` \"executable\" with `chmod +x {}`?".format(matches.group(1), matches.group(1)))
-        return (1, after)
+            response.append("Did you remember to make `{}` \"executable\" with `chmod +x {}`?".format(matches.group(1), matches.group(1)))
+        return (1, response)

--- a/helpers/bash.py
+++ b/helpers/bash.py
@@ -10,7 +10,7 @@ def help(lines):
             "Did you misspell `{}`?".format(matches.group(1)),
             "Did you mean to execute `./{}`?".format(matches.group(1))
         ]
-        return (lines[0:1], after)
+        return (1, after)
 
     # $ cd foo
     # bash: cd: foo: No such file or directory
@@ -20,7 +20,7 @@ def help(lines):
             "Are you sure `{}` exists".format(matches.group(1)),
             "Did you misspell `{}`?".format(matches.group(1))
         ]
-        return (lines[0:1], after)
+        return (1, after)
 
     # $ ./foo
     # bash: ./foo: Permission denied
@@ -39,4 +39,4 @@ def help(lines):
             after.append("Did you mean to execute `ruby {}`?".format(matches.group(1)))
         else:
             after.append("Did you remember to make `{}` \"executable\" with `chmod +x {}`?".format(matches.group(1), matches.group(1)))
-        return (lines[0:1], after)
+        return (1, after)

--- a/helpers/clang.py
+++ b/helpers/clang.py
@@ -5,11 +5,11 @@ def help(lines):
     # foo.c:13:25: error: adding 'int' to a string does not append to the string [-Werror,-Wstring-plus-int]
     matches = re.search(r"^([^:]+):(\d+):\d+: error: adding '(.+)' to a string does not append to the string", lines[0])
     if matches:
-        after = ["Careful, you can't concatenate values and strings in C using the `+` operator, as you seem to be trying to do on line {} of `{}`.".format(matches.group(2), matches.group(1))]
+        response = ["Careful, you can't concatenate values and strings in C using the `+` operator, as you seem to be trying to do on line {} of `{}`.".format(matches.group(2), matches.group(1))]
         if len(lines) >= 2 and re.search(r"printf\s*\(", lines[1]):
-            after.append("Odds are you want to provide `printf` with a format code for that value and pass that value to `printf` as an argument.")
-            return (2, after)
-        return (1, after)
+            response.append("Odds are you want to provide `printf` with a format code for that value and pass that value to `printf` as an argument.")
+            return (2, response)
+        return (1, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -20,8 +20,8 @@ def help(lines):
     # foo.c:7:1: error: control may reach end of non-void function [-Werror,-Wreturn-type]
     matches = re.search(r"control (may)?reach(es)? end of non-void function", lines[0])
     if matches:
-        after = ["Ensure that your function will always return a value. If your function is not meant to return a value, try changing its return type to `void`."]
-        return (1, after)
+        response = ["Ensure that your function will always return a value. If your function is not meant to return a value, try changing its return type to `void`."]
+        return (1, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -30,14 +30,14 @@ def help(lines):
     #           ~~~~~~~          ^
     matches = re.search(r"^([^:]+):(\d+):\d+: (?:warning|error): data argument not used by format string", lines[0])
     if matches:
-        after = [
+        response = [
             "You have more arguments in your formatted string on line {} of `{}` than you have format codes.".format(matches.group(2), matches.group(1)),
             "Make sure that the number of format codes equals the number of additional arguments.",
             "Try either adding format code(s) or removing argument(s)."
         ]
         if len(lines) >= 2 and re.search(r"%", lines[1]):
-            return (2, after)
-        return (1, after)
+            return (2, response)
+        return (1, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -52,7 +52,7 @@ def help(lines):
     #                    ^
     matches = re.search(r"^([^:]+):(\d+):\d+: (?:warning|error): declaration shadows a local variable", lines[0])
     if matches:
-        after = [
+        response = [
             "On line {} of `{}`, it seems that you're trying to create a new variable that has already been created.".format(matches.group(2), matches.group(1))
         ]
 
@@ -60,10 +60,10 @@ def help(lines):
         if len(lines) >= 2:
             for_loop = re.search(r"^\s*for\s*\(", lines[1])
             if for_loop:
-                after.append("If you meant to create a `for` loop, be sure that each part of the `for` loop is separated with a semicolon rather than a comma.")
+                response.append("If you meant to create a `for` loop, be sure that each part of the `for` loop is separated with a semicolon rather than a comma.")
                 if (len(lines) >= 3 and re.search(r"^\s*\^$", lines[2])):
-                    return (3, after)
-                return (2, after)
+                    return (3, response)
+                return (2, response)
 
         # see if we can get the line number of the previous declaration of the variable
         prev_declaration_file = None
@@ -78,14 +78,14 @@ def help(lines):
         if prev_declaration_line and prev_declaration_file:
             omit_suggestion += " (on line {} of `{}`)".format(prev_declaration_line, prev_declaration_file)
         omit_suggestion += ", try getting rid of the data type of the variable on line {} of `{}`. You only need to include the data type when you first declare a variable.".format(matches.group(2), matches.group(1))
-        after.append(omit_suggestion)
-        after.append("Otherwise, if you did mean to declare a new variable, try changing its name to a name that hasn't been used yet.")
+        response.append(omit_suggestion)
+        response.append("Otherwise, if you did mean to declare a new variable, try changing its name to a name that hasn't been used yet.")
         
         if len(lines) >= 4 and prev_declaration_line != None:
-            return (6, after) if len(lines) >= 6 and re.search(r"^\s*\^$", lines[5]) else (4, after)
+            return (6, response) if len(lines) >= 6 and re.search(r"^\s*\^$", lines[5]) else (4, response)
         if len(lines) >= 2:
-            return (2, after)
-        return (1, after)
+            return (2, response)
+        return (1, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -94,13 +94,13 @@ def help(lines):
     # ^
     matches = re.search(r"^([^:]+):(\d+):\d+: error: expected identifier or '\('", lines[0])
     if matches:
-        after = [
+        response = [
             "Looks like `clang` is having some trouble understanding where your functions start and end in your code.",
             "Are you defining a function (like `main` or some other function) somewhere just before line {} of `{}`?".format(matches.group(2), matches.group(1)),
             "If so, make sure the function header (the line that introduces the name of the function) doesn't end with a semicolon.",
             "Also check to make sure that all of the code for your function is inside of curly braces."
         ]
-        return (1, after)
+        return (1, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -109,13 +109,13 @@ def help(lines):
     #            ^
     matches = re.search(r"^([^:]+):(\d+):\d+: error: expected parameter declarator", lines[0])
     if matches:
-        after = [
+        response = [
             "If you're trying to call a function on line {} of `{}`, be sure that you're calling it inside of curly braces within a function. Also check that the function's header (the line introducing the function's name) doesn't end in a semicolon.".format(matches.group(2), matches.group(1)),
             "Alternatively, if you're trying to declare a function or prototype on line {} of `{}`, be sure each argument to the function is formatted as a data type followed by a variable name.".format(matches.group(2), matches.group(1))
         ]
         if len(lines) >= 3 and re.search(r"^\s*\^$", lines[2]):
-            return (3, after)
-        return (1, after)
+            return (3, response)
+        return (1, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -124,8 +124,8 @@ def help(lines):
     #  ^
     matches = re.search(r"error: expected '}'", lines[0])
     if matches:
-        after = ["Make sure that all opening brace symbols `{` are matched with a closing brace `}`."]
-        return (1, after)
+        response = ["Make sure that all opening brace symbols `{` are matched with a closing brace `}`."]
+        return (1, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -134,12 +134,12 @@ def help(lines):
     #        ^
     matches = re.search(r"^([^:]+):(\d+):\d+: (?:warning|error): expected '\(' after 'if'", lines[0])
     if matches:
-        after = [
+        response = [
             "In your `if` statement on line {} of `{}`, be sure that you're enclosing the condition you're testing within parentheses.".format(matches.group(2), matches.group(1))
         ]
         if len(lines) >= 2 and re.search(r"if\s*\(", lines[1]):
-            return (2, after)
-        return (1, after)
+            return (2, response)
+        return (1, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -150,20 +150,20 @@ def help(lines):
     if matches:
         # assume that the line number for the matching ')' is the line that generated the error
         match_line = matches.group(2)
-        before = 1
+        n = 1
 
         # if there's a note on which '(' to match, use that line number instead
         if (len(lines) >= 4):
             parens_match = re.search(r"^([^:]+):(\d+):\d+: note: to match this '\('", lines[3])
             if parens_match:
                 match_line = parens_match.group(2)
-                before = 4
+                n = 4
 
-        after = [
+        response = [
             "Make sure that all opening parentheses `(` are matched with a closing parenthesis `)` in {}.".format(matches.group(1)),
             "In particular, check to see if you are missing a closing parenthesis on line {} of {}.".format(match_line, matches.group(1))
         ]
-        return (before, after)
+        return (n, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -173,12 +173,12 @@ def help(lines):
     #                           ;
     matches = re.search(r"^([^:]+):(\d+):\d+: error: expected ';' (?:after expression|at end of declaration|after do\/while statement)", lines[0])
     if matches:
-        after = ["Try including a semicolon at the end of line {} of `{}`.".format(matches.group(2), matches.group(1))]
+        response = ["Try including a semicolon at the end of line {} of `{}`.".format(matches.group(2), matches.group(1))]
         if len(lines) >= 3 and re.search(r"^\s*\^$", lines[2]):
             if len(lines) >= 4 and re.search(r"^\s*;$", lines[3]):
-                return (4, after)
-            return (3, after)
-        return (1, after)
+                return (4, response)
+            return (3, response)
+        return (1, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -187,20 +187,20 @@ def help(lines):
     #                      ^
     matches = re.search(r"^[^:]+:(\d+):\d+: error: expected ';' in 'for' statement specifier", lines[0])
     if matches:
-        after = ["Be sure to separate the three components of the 'for' loop on line {} with semicolons.".format(matches.group(1))]
+        response = ["Be sure to separate the three components of the 'for' loop on line {} with semicolons.".format(matches.group(1))]
         if len(lines) >= 2 and re.search(r"for\s*\(", lines[1]):
-            return (2, after)
-        return (1, after)
+            return (2, response)
+        return (1, response)
     
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
     # foo.c:28:28: error: expected expression
     matches = re.search(r"^([^:]+):(\d+):\d+: error: expected expression", lines[0])
     if matches:
-        after = [
+        response = [
             "Not quite sure how to help, but focus your attention on line {} of `{}`!".format(matches.group(2), matches.group(1))
         ]
-        return (1, after)
+        return (1, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -209,18 +209,18 @@ def help(lines):
     #                   ^
     matches = re.search(r"^([^:]+):(\d+):(\d+): (?:warning|error): extra tokens at end of #include directive", lines[0])
     if matches:
-        after = [
+        response = [
             "You seem to have an error in `{}` on line {} at character {}.".format(matches.group(1), matches.group(2), matches.group(3)),
             "By \"extra tokens\", `clang` means that you have one or more extra characters on that line that you shouldn't."
         ]
         if len(lines) >= 3 and re.search(r"^\s*\^", lines[2]):
             token = lines[1][lines[2].index("^")]
             if token == ";":
-                after.append("Try removing the semicolon at the end of that line.")
+                response.append("Try removing the semicolon at the end of that line.")
             else:
-                after.append("Try removing the `{}` at the end of that line.".format(token))
-            return (2, after)
-        return (1, after)
+                response.append("Try removing the `{}` at the end of that line.".format(token))
+            return (2, response)
+        return (1, response)
     
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -229,17 +229,17 @@ def help(lines):
     #          ^
     matches = re.search(r"^([^:]+):(\d+):\d+: fatal error: '(.*)' file not found", lines[0])
     if matches:
-        after = [
+        response = [
             "Looks like you're trying to `#include` a file (`{}`) on line {} of `{}` which does not exist.".format(matches.group(3), matches.group(2), matches.group(1))
         ]
         if matches.group(3) in ["studio.h"]:
-            after.append("Did you mean to `#include <stdio.h>` (without the `u`)?")
+            response.append("Did you mean to `#include <stdio.h>` (without the `u`)?")
         else:
-            after.append("Check to make sure you spelled the filename correctly.")
+            response.append("Check to make sure you spelled the filename correctly.")
             
         if len(lines) >= 2 and re.search(r"#include", lines[1]):
-            return (2, after)
-        return (1, after)
+            return (2, response)
+        return (1, response)
 
     # $ clang foo.c
     # foo.c:6:16: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
@@ -251,8 +251,8 @@ def help(lines):
         matches = re.search(r"^(.?printf|.?scanf)\s*\(", lines[1][lines[2].index("^"):])
         print(lines[1][lines[2].index("^"):])
         if matches:
-            after = ["The first argument to `{}` on line {} of `{}` should be a double-quoted string.".format(matches.group(1), line, file)]
-            return (2, after)
+            response = ["The first argument to `{}` on line {} of `{}` should be a double-quoted string.".format(matches.group(1), line, file)]
+            return (2, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -261,19 +261,19 @@ def help(lines):
     #            ^
     matches = re.search(r"^([^:]+):(\d+):(\d+): (?:warning|error): implicit declaration of function '([^']+)' is invalid", lines[0])
     if matches:
-        after = [
+        response = [
             "You seem to have an error in `{}` on line {} at character {}.".format(matches.group(1), matches.group(2), matches.group(3)),
             "By \"implicit declaration of function '{}'\", `clang` means that it doesn't recognize `{}`.".format(matches.group(4), matches.group(4))
         ]
         if matches.group(4) in ["eprintf", "get_char", "get_double", "get_float", "get_int", "get_long", "get_long_long", "get_string", "GetChar", "GetDouble", "GetFloat", "GetInt", "GetLong", "GetLongLong", "GetString"]:
-            after.append("Did you forget to `#include <cs50.h>` (in which `{}` is declared) atop your file?".format(matches.group(4)))
+            response.append("Did you forget to `#include <cs50.h>` (in which `{}` is declared) atop your file?".format(matches.group(4)))
         else:
-            after.append("Did you forget to `#include` the header file in which `{}` is declared atop your file?".format(matches.group(4)))
-            after.append("Did you forget to declare a prototype for `{}` atop `{}`?".format(matches.group(4), matches.group(1)))
+            response.append("Did you forget to `#include` the header file in which `{}` is declared atop your file?".format(matches.group(4)))
+            response.append("Did you forget to declare a prototype for `{}` atop `{}`?".format(matches.group(4), matches.group(1)))
             
         if len(lines) >= 2 and re.search(matches.group(4), lines[1]):
-            return (2, after)
-        return (1, after)
+            return (2, response)
+        return (1, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -283,13 +283,13 @@ def help(lines):
     matches = re.search(r"implicitly declaring library function '([^']+)'", lines[0])
     if matches:
         if (matches.group(1) == "printf"):
-            after = ["Did you forget to `#include <stdio.h>` (in which `printf` is declared) atop your file?"]
+            response = ["Did you forget to `#include <stdio.h>` (in which `printf` is declared) atop your file?"]
         else:
-            after = ["Did you forget to `#include` the header file in which `{}` is declared) atop your file?".format(matches.group(1))]
+            response = ["Did you forget to `#include` the header file in which `{}` is declared) atop your file?".format(matches.group(1))]
             
         if len(lines) >= 2 and re.search(r"printf\s*\(", lines[1]):
-            return (2, after)
-        return (1, after)
+            return (2, response)
+        return (1, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -299,10 +299,10 @@ def help(lines):
     #        ^   ~~~~
     matches = re.search(r"incompatible ([^']+) to ([^']+) conversion", lines[0])
     if matches:
-        after = ["By \"incompatible conversion\", `clang` means that you are assigning a value to a variable of a different type. Try ensuring that your value is of type `{}`.".format(matches.group(2))]
+        response = ["By \"incompatible conversion\", `clang` means that you are assigning a value to a variable of a different type. Try ensuring that your value is of type `{}`.".format(matches.group(2))]
         if len(lines) >= 2 and re.search(r"=", lines[1]):
-            return (2, after)
-        return (1, after)
+            return (2, response)
+        return (1, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -312,12 +312,12 @@ def help(lines):
     #            %s
     matches = re.search(r"^[^:]+:(\d+):\d+: error: format specifies type '[^:]+' but the argument has type '[^:]+'", lines[0])
     if matches:
-        after = ["Be sure to use the correct format code (%i for integers, %f for floating point values, %s for strings) in your string format statement on line {}.".format(matches.group(1))]
+        response = ["Be sure to use the correct format code (%i for integers, %f for floating point values, %s for strings) in your string format statement on line {}.".format(matches.group(1))]
         if len(lines) >= 3 and re.search(r"\^", lines[2]):
             if len(lines) >= 4 and re.search(r"%", lines[3]):
-                return (4, after)
-            return (3, after)
-        return (1, after)
+                return (4, response)
+            return (3, response)
+        return (1, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -326,13 +326,13 @@ def help(lines):
     #  ^
     matches = re.search(r"^[^:]+:(\d+):\d+: error: invalid preprocessing directive", lines[0])
     if matches:
-        after = ["By \"invalid preprocesing directive\", `clang` means that you've used a preprocessor command on line {} (a command beginning with #) that is not recognized.".format(matches.group(1))]
+        response = ["By \"invalid preprocesing directive\", `clang` means that you've used a preprocessor command on line {} (a command beginning with #) that is not recognized.".format(matches.group(1))]
         if len(lines) >= 2:
             directive = re.search(r"^([^' ]+)", lines[1])
             if directive:
-                after.append("Check to make sure that `{}` is a valid directive (like `#include`) and is spelled correctly.".format(directive.group(1)))
-                return (2, after)
-        return (1, after)
+                response.append("Check to make sure that `{}` is a valid directive (like `#include`) and is spelled correctly.".format(directive.group(1)))
+                return (2, response)
+        return (1, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -341,14 +341,14 @@ def help(lines):
     #               ~^
     matches = re.search(r"^([^:]+):(\d+):\d+: (?:warning|error): more '%' conversions than data arguments", lines[0])
     if matches:
-        after = [
+        response = [
             "You have too many format codes (e.g. %i or %s) in your formatted string on line {} of `{}`.".format(matches.group(2), matches.group(1)),
             "Make sure that the number of format codes equals the number of additional arguments.",
             "Try either removing format code(s) or adding additional argument(s)"
         ]
         if len(lines) >= 2 and re.search(r"%", lines[1]):
-            return (2, after)
-        return (1, after)
+            return (2, response)
+        return (1, response)
     
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -357,13 +357,13 @@ def help(lines):
     # ^
     matches = re.search(r"^([^:]+):(\d+):\d+: (?:warning|error): type specifier missing, defaults to 'int'", lines[0])
     if matches:
-        after = [
+        response = [
             "Looks like you're trying to declare a function on line {} of `{}`.".format(matches.group(2), matches.group(1)),
             "Be sure that when you're declaring a function, you specify its return type just before the name of the function."
         ]
         if len(lines) >= 3 and re.search(r"^\s*\^$", lines[2]):
-            return (3, after)
-        return (1, after)
+            return (3, response)
+        return (1, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -372,10 +372,10 @@ def help(lines):
     #        ~~^~~~
     matches = re.search(r"^[^:]+:(\d+):\d+: (?:warning|error): using the result of an assignment as a condition without parentheses", lines[0])
     if matches:
-        after = ["When checking for equality in the condition on line {}, try using a double equals sign (`==`) instead of a single equals sign (`=`).".format(matches.group(1))]
+        response = ["When checking for equality in the condition on line {}, try using a double equals sign (`==`) instead of a single equals sign (`=`).".format(matches.group(1))]
         if len(lines) >= 2 and re.search(r"if\s*\(", lines[1]):
-            return (2, after)
-        return (1, after)
+            return (2, response)
+        return (1, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -384,30 +384,30 @@ def help(lines):
     #    ^
     matches = re.search(r"use of undeclared identifier '([^']+)'", lines[0])
     if matches:
-        after = ["By \"undeclared identifier,\" `clang` means you've used a name `{}` which hasn't been defined.".format(matches.group(1))]
+        response = ["By \"undeclared identifier,\" `clang` means you've used a name `{}` which hasn't been defined.".format(matches.group(1))]
         if matches.group(1) in ["true", "false", "bool", "string"]:
-            after.append("Did you forget to `#include <cs50.h>` (in which `{}` is defined) atop your file?".format(matches.group(1)))
+            response.append("Did you forget to `#include <cs50.h>` (in which `{}` is defined) atop your file?".format(matches.group(1)))
         else:
-            after.append("If you mean to use `{}` as a variable, make sure to declare it by specifying its type, and check that the variable name is spelled correctly.".format(matches.group(1)))
+            response.append("If you mean to use `{}` as a variable, make sure to declare it by specifying its type, and check that the variable name is spelled correctly.".format(matches.group(1)))
         if len(lines) >= 2 and re.search(matches.group(1), lines[1]):
-            return (2, after)
-        return (1, after)
+            return (2, response)
+        return (1, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
     # foo.c:(.text+0x9): undefined reference to `get_int'
     matches = re.search(r"undefined reference to `([^']+)'", lines[0])
     if matches:
-        after = ["By \"undefined reference,\" `clang` means that you've called a function, `{}`, that doesn't seem to be implemented. If that function has, in fact, been implemented, odds are you've forgotten to tell `clang` to \"link\" against the file that implements `{}`.".format(matches.group(1), matches.group(1))]
+        response = ["By \"undefined reference,\" `clang` means that you've called a function, `{}`, that doesn't seem to be implemented. If that function has, in fact, been implemented, odds are you've forgotten to tell `clang` to \"link\" against the file that implements `{}`.".format(matches.group(1), matches.group(1))]
         if matches.group(1) in ["eprintf", "get_char", "get_double", "get_float", "get_int", "get_long", "get_long_long", "get_string"]:
-            after.append("Did you forget to compile with `-lcs50` in order to link against against the CS50 Library, which implements `{}`?".format(matches.group(1)))
+            response.append("Did you forget to compile with `-lcs50` in order to link against against the CS50 Library, which implements `{}`?".format(matches.group(1)))
         elif matches.group(1) in ["GetChar", "GetDouble", "GetFloat", "GetInt", "GetLong", "GetLongLong", "GetString"]:
-            after.append("Did you forget to compile with `-lcs50` in order to link against against the CS50 Library, which implements `{}`?".format(matches.group(1)))
+            response.append("Did you forget to compile with `-lcs50` in order to link against against the CS50 Library, which implements `{}`?".format(matches.group(1)))
         elif matches.group(1) == "crypt":
-            after.append("Did you forget to compile with -lcrypt in order to link against the crypto library, which implemens `crypt`?")
+            response.append("Did you forget to compile with -lcrypt in order to link against the crypto library, which implemens `crypt`?")
         else:
-            after.append("Did you forget to compile with `-lfoo`, where `foo` is the library that defines `{}`?".format(matches.group(1)))
-        return (1, after)
+            response.append("Did you forget to compile with `-lfoo`, where `foo` is the library that defines `{}`?".format(matches.group(1)))
+        return (1, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -416,8 +416,8 @@ def help(lines):
     # ^
     matches = re.search(r"unknown type name 'include'", lines[0])
     if matches:
-        after = ["Try including header files via `#include` rather than just `include`."]
-        return (2, after) if len(lines) >= 2 else (1, after)
+        response = ["Try including header files via `#include` rather than just `include`."]
+        return (2, response) if len(lines) >= 2 else (1, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -426,8 +426,8 @@ def help(lines):
     #         ^
     matches = re.search(r"unused variable '([^']+)'", lines[0])
     if matches:
-        after = ["It seems that the variable `{}` is never in your program. Try either removing it altogether or using it.".format(matches.group(1))]
-        return (1, after)
+        response = ["It seems that the variable `{}` is never in your program. Try either removing it altogether or using it.".format(matches.group(1))]
+        return (1, response)
     
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -436,14 +436,14 @@ def help(lines):
     #                    ^
     matches = re.search(r"^([^:]+):(\d+):\d+: (?:warning|error): variable '(.*)' is uninitialized when used here", lines[0])
     if matches:
-        after = [
+        response = [
             "It looks like you're trying to use the variable `{}` on line {} of `{}`.".format(matches.group(3), matches.group(2), matches.group(1)),
             "However, on that line, the variable `{}` doesn't have a value yet.".format(matches.group(3)),
             "Be sure to assign a value to `{}` before trying to access its value.".format(matches.group(3))
         ]
         if len(lines) >= 2 and re.search(matches.group(3), lines[1]):
-            return (2, after)
-        return (1, after)
+            return (2, response)
+        return (1, response)
     
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -452,9 +452,9 @@ def help(lines):
     #             ^
     matches = re.search(r"^([^:]+):(\d+):\d+: (?:warning|error): (if statement|while loop|for loop) has empty body", lines[0])
     if matches:
-        after = [
+        response = [
             "Try removing the semicolon directly after the closing parentheses of the `{}` on line {} of `{}`.".format(matches.group(3),matches.group(2), matches.group(1))
         ]
         if len(lines) >= 2 and re.search(r"if\s*\(", lines[1]):
-            return (2, after)
-        return (1, after)
+            return (2, response)
+        return (1, response)

--- a/helpers/clang.py
+++ b/helpers/clang.py
@@ -8,7 +8,7 @@ def help(lines):
         after = ["Careful, you can't concatenate values and strings in C using the `+` operator, as you seem to be trying to do on line {} of `{}`.".format(matches.group(2), matches.group(1))]
         if len(lines) >= 2 and re.search(r"printf\s*\(", lines[1]):
             after.append("Odds are you want to provide `printf` with a format code for that value and pass that value to `printf` as an argument.")
-        return (lines[0:1], after)
+        return (1, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -20,7 +20,7 @@ def help(lines):
     matches = re.search(r"control (may)?reach(es)? end of non-void function", lines[0])
     if matches:
         after = ["Ensure that your function will always return a value. If your function is not meant to return a value, try changing its return type to `void`."]
-        return (lines[0:1], after)
+        return (1, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -34,7 +34,7 @@ def help(lines):
             "Make sure that the number of format codes equals the number of additional arguments.",
             "Try either adding format code(s) or removing argument(s)."
         ]
-        return (lines[0:1], after)
+        return (1, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -58,7 +58,7 @@ def help(lines):
             for_loop = re.search(r"^\s*for\s*\(", lines[1])
             if for_loop:
                 after.append("If you meant to create a `for` loop, be sure that each part of the `for` loop is separated with a semicolon rather than a comma.")
-                return (lines[0:2], after)
+                return (2, after)
 
         # see if we can get the line number of the previous declaration of the variable
         prev_declaration_file = None
@@ -76,7 +76,7 @@ def help(lines):
         after.append(omit_suggestion)
         after.append("Otherwise, if you did mean to declare a new variable, try changing its name to a name that hasn't been used yet.")
 
-        return (lines[0:4], after) if len(lines) >= 4 else (lines[0:1], after)
+        return (4, after) if len(lines) >= 4 else (1, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -91,7 +91,7 @@ def help(lines):
             "If so, make sure the function header (the line that introduces the name of the function) doesn't end with a semicolon.",
             "Also check to make sure that all of the code for your function is inside of curly braces."
         ]
-        return (lines[0:1], after)
+        return (1, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -104,7 +104,7 @@ def help(lines):
             "If you're trying to call a function on line {} of `{}`, be sure that you're calling it inside of curly braces within a function. Also check that the function's header (the line introducing the function's name) doesn't end in a semicolon.".format(matches.group(2), matches.group(1)),
             "Alternatively, if you're trying to declare a function or prototype on line {} of `{}`, be sure each argument to the function is formatted as a data type followed by a variable name.".format(matches.group(2), matches.group(1))
         ]
-        return (lines[0:1], after)
+        return (1, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -114,7 +114,7 @@ def help(lines):
     matches = re.search(r"error: expected '}'", lines[0])
     if matches:
         after = ["Make sure that all opening brace symbols `{` are matched with a closing brace `}`."]
-        return (lines[0:1], after)
+        return (1, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -126,7 +126,7 @@ def help(lines):
         after = [
             "In your `if` statement on line {} of `{}`, be sure that you're enclosing the condition you're testing within parentheses.".format(matches.group(2), matches.group(1))
         ]
-        return (lines[0:1], after)
+        return (1, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -137,7 +137,7 @@ def help(lines):
     if matches:
         # assume that the line number for the matching ')' is the line that generated the error
         match_line = matches.group(2)
-        before = lines[0:1]
+        before = 1
 
         # if there's a note on which '(' to match, use that line number instead
         if (len(lines) >= 4):
@@ -161,7 +161,7 @@ def help(lines):
     matches = re.search(r"^([^:]+):(\d+):\d+: error: expected ';' (?:after expression|at end of declaration|after do\/while statement)", lines[0])
     if matches:
         after = ["Try including a semicolon at the end of line {} of `{}`.".format(matches.group(2), matches.group(1))]
-        return (lines[0:1], after)
+        return (1, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -171,7 +171,7 @@ def help(lines):
     matches = re.search(r"^[^:]+:(\d+):\d+: error: expected ';' in 'for' statement specifier", lines[0])
     if matches:
         after = ["Be sure to separate the three components of the 'for' loop on line {} with semicolons.".format(matches.group(1))]
-        return (lines[0:1], after)
+        return (1, after)
     
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -181,7 +181,7 @@ def help(lines):
         after = [
             "Not quite sure how to help, but focus your attention on line {} of `{}`!".format(matches.group(2), matches.group(1))
         ]
-        return (lines[0:1], after)
+        return (1, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -200,8 +200,8 @@ def help(lines):
                 after.append("Try removing the semicolon at the end of that line.")
             else:
                 after.append("Try removing the `{}` at the end of that line.".format(token))
-            return (lines[0:3], after)
-        return (lines[0:1], after)
+            return (3, after)
+        return (1, after)
     
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -217,7 +217,7 @@ def help(lines):
             after.append("Did you mean to `#include <stdio.h>` (without the `u`)?")
         else:
             after.append("Check to make sure you spelled the filename correctly.")
-        return (lines[0:1], after)
+        return (1, after)
 
     # $ clang foo.c
     # foo.c:6:16: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
@@ -230,7 +230,7 @@ def help(lines):
         print(lines[1][lines[2].index("^"):])
         if matches:
             after = ["The first argument to `{}` on line {} of `{}` should be a double-quoted string.".format(matches.group(1), line, file)]
-            return (lines[0:1], after)
+            return (1, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -248,7 +248,7 @@ def help(lines):
         else:
             after.append("Did you forget to `#include` the header file in which `{}` is declared atop your file?".format(matches.group(4)))
             after.append("Did you forget to declare a prototype for `{}` atop `{}`?".format(matches.group(4), matches.group(1)))
-        return (lines[0:1], after)
+        return (1, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -261,7 +261,7 @@ def help(lines):
             after = ["Did you forget to `#include <stdio.h>` (in which `printf` is declared) atop your file?"]
         else:
             after = ["Did you forget to `#include` the header file in which `{}` is declared) atop your file?".format(matches.group(1))]
-        return (lines[0:1], after)
+        return (1, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -272,7 +272,7 @@ def help(lines):
     matches = re.search(r"incompatible ([^']+) to ([^']+) conversion", lines[0])
     if matches:
         after = ["By \"incompatible conversion\", `clang` means that you are assigning a value to a variable of a different type. Try ensuring that your value is of type `{}`.".format(matches.group(2))]
-        return (lines[0:1], after)
+        return (1, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -283,7 +283,7 @@ def help(lines):
     matches = re.search(r"^[^:]+:(\d+):\d+: error: format specifies type '[^:]+' but the argument has type '[^:]+'", lines[0])
     if matches:
         after = ["Be sure to use the correct format code (%i for integers, %f for floating point values, %s for strings) in your string format statement on line {}.".format(matches.group(1))]
-        return (lines[0:1], after)
+        return (1, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -297,8 +297,8 @@ def help(lines):
             directive = re.search(r"^([^' ]+)", lines[1])
             if directive:
                 after.append("Check to make sure that `{}` is a valid directive (like `#include`) and is spelled correctly.".format(directive.group(1)))
-                return (lines[0:2], after)
-        return (lines[0:1], after)
+                return (2, after)
+        return (1, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -312,7 +312,7 @@ def help(lines):
             "Make sure that the number of format codes equals the number of additional arguments.",
             "Try either removing format code(s) or adding additional argument(s)"
         ]
-        return (lines[0:1], after)
+        return (1, after)
     
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -325,7 +325,7 @@ def help(lines):
             "Looks like you're trying to declare a function on line {} of `{}`.".format(matches.group(2), matches.group(1)),
             "Be sure that when you're declaring a function, you specify its return type just before the name of the function."
         ]
-        return (lines[0:1], after)
+        return (1, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -335,7 +335,7 @@ def help(lines):
     matches = re.search(r"^[^:]+:(\d+):\d+: (?:warning|error): using the result of an assignment as a condition without parentheses", lines[0])
     if matches:
         after = ["When checking for equality in the condition on line {}, try using a double equals sign (`==`) instead of a single equals sign (`=`).".format(matches.group(1))]
-        return (lines[0:1], after)
+        return (1, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -349,7 +349,7 @@ def help(lines):
             after.append("Did you forget to `#include <cs50.h>` (in which `{}` is defined) atop your file?".format(matches.group(1)))
         else:
             after.append("If you mean to use `{}` as a variable, make sure to declare it by specifying its type, and check that the variable name is spelled correctly.".format(matches.group(1)))
-        return (lines[0:1], after)
+        return (1, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -365,7 +365,7 @@ def help(lines):
             after.append("Did you forget to compile with -lcrypt in order to link against the crypto library, which implemens `crypt`?")
         else:
             after.append("Did you forget to compile with `-lfoo`, where `foo` is the library that defines `{}`?".format(matches.group(1)))
-        return (lines[0:1], after)
+        return (1, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -375,7 +375,7 @@ def help(lines):
     matches = re.search(r"unknown type name 'include'", lines[0])
     if matches:
         after = ["Try including header files via `#include` rather than just `include`."]
-        return (lines[0:2], after)
+        return (2, after)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -385,7 +385,7 @@ def help(lines):
     matches = re.search(r"unused variable '([^']+)'", lines[0])
     if matches:
         after = ["It seems that the variable `{}` is never in your program. Try either removing it altogether or using it.".format(matches.group(1))]
-        return (lines[0:1], after)
+        return (1, after)
     
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -399,7 +399,7 @@ def help(lines):
             "However, on that line, the variable `{}` doesn't have a value yet.".format(matches.group(3)),
             "Be sure to assign a value to `{}` before trying to access its value.".format(matches.group(3))
         ]
-        return (lines[0:1], after)
+        return (1, after)
     
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -410,4 +410,4 @@ def help(lines):
     if matches:
         if len(lines) >= 2 and re.search(r"^\s*if.*;$", lines[1]):
             after = ["Try removing the semicolon after the condition in the `if` statement."]
-            return (lines[0:2], after)
+            return (2, after)

--- a/helpers/cp.py
+++ b/helpers/cp.py
@@ -15,7 +15,7 @@ def help(lines):
         interpretation += "there " if new_dir else "in the current directory "
         interpretation += "with the same name."
         
-        after = [interpretation]
-        after.append("To copy the file, replacing the old version, type `y` and press return.")
-        after.append("Typing `n` and pressing return will cancel copying.")
-        return (1, after)
+        response = [interpretation]
+        response.append("To copy the file, replacing the old version, type `y` and press return.")
+        response.append("Typing `n` and pressing return will cancel copying.")
+        return (1, response)

--- a/helpers/cp.py
+++ b/helpers/cp.py
@@ -18,4 +18,4 @@ def help(lines):
         after = [interpretation]
         after.append("To copy the file, replacing the old version, type `y` and press return.")
         after.append("Typing `n` and pressing return will cancel copying.")
-        return (lines[0:1], after)
+        return (1, after)

--- a/helpers/make.py
+++ b/helpers/make.py
@@ -5,36 +5,36 @@ def help(lines):
     # make: `foo' is up to date.
     matches = re.search(r"^make: `(.+)' is up to date.", lines[0])
     if matches:
-        after = [
+        response = [
             "Looks like you already compiled `{}` and haven't made any changes to `{}.c` since.".format(matches.group(1), matches.group(1)),
             "Or did you forget to save `{}.c` before running `make`?".format(matches.group(1))
         ]
-        return (1, after)
+        return (1, response)
 
     # $ make foo
     # make: *** No rule to make target `foo'.  Stop.
     matches = re.search(r"^make: \*\*\* No rule to make target `(.+)'.  Stop.", lines[0])
     if matches:
-        after = [
+        response = [
             "Do you actually have a file called `{}.c` in the current directory?".format(matches.group(1)),
             "If using a Makefile, are you sure you have a target called `{}`?".format(matches.group(1))
         ]
-        return (1, after)
+        return (1, response)
     
     # $ make foo.c
     # make: Nothing to be done for `foo.c'.
     matches = re.search(r"^make: Nothing to be done for `([^']+).c'.", lines[0])
     if matches:
-        after = [
+        response = [
             "Try compiling your program with `make {}` rather than `make {}.c`.".format(matches.group(1), matches.group(1))
         ]
-        return (1, after)
+        return (1, response)
     
     # $ make foo
     # clang -ggdb3 -O0 -std=c11 -Wall -Werror -Wshadow foo.c -lcs50 -lm -o foo
     matches = re.search(r"^clang", lines[0])
     if matches and len(lines) == 1 and "error:" not in lines[0]:
-        after = [
+        response = [
             "Looks like your program compiles successfully!"
         ]
-        return (1, after)
+        return (1, response)

--- a/helpers/make.py
+++ b/helpers/make.py
@@ -9,7 +9,7 @@ def help(lines):
             "Looks like you already compiled `{}` and haven't made any changes to `{}.c` since.".format(matches.group(1), matches.group(1)),
             "Or did you forget to save `{}.c` before running `make`?".format(matches.group(1))
         ]
-        return (lines[0:1], after)
+        return (1, after)
 
     # $ make foo
     # make: *** No rule to make target `foo'.  Stop.
@@ -19,7 +19,7 @@ def help(lines):
             "Do you actually have a file called `{}`.c?".format(matches.group(1)),
             "If using a Makefile, are you sure you have a target called `{}`?".format(matches.group(1))
         ]
-        return (lines[0:1], after)
+        return (1, after)
     
     # $ make foo.c
     # make: Nothing to be done for `foo.c'.
@@ -28,7 +28,7 @@ def help(lines):
         after = [
             "Try compiling your program with `make {}` rather than `make {}.c`.".format(matches.group(1), matches.group(1))
         ]
-        return (lines[0:1], after)
+        return (1, after)
     
     # $ make foo
     # clang -ggdb3 -O0 -std=c11 -Wall -Werror -Wshadow foo.c -lcs50 -lm -o foo
@@ -37,4 +37,4 @@ def help(lines):
         after = [
             "Looks like your program compiles successfully!"
         ]
-        return (lines[0:1], after)
+        return (1, after)

--- a/helpers/mv.py
+++ b/helpers/mv.py
@@ -21,4 +21,4 @@ def help(lines):
         after.append("To replace the old file, type `y` and press return.")
         after.append("Typing `n` and pressing return will cancel the operation.")
         
-        return (lines[0:1], after)
+        return (1, after)

--- a/helpers/mv.py
+++ b/helpers/mv.py
@@ -17,8 +17,8 @@ def help(lines):
         interpretation += "a file to `{}`, but there is already a file with the same name ".format(matches.group(1))
         interpretation += "there." if moving else "in the current directory."
         
-        after = [interpretation]
-        after.append("To replace the old file, type `y` and press return.")
-        after.append("Typing `n` and pressing return will cancel the operation.")
+        response = [interpretation]
+        response.append("To replace the old file, type `y` and press return.")
+        response.append("Typing `n` and pressing return will cancel the operation.")
         
-        return (1, after)
+        return (1, response)

--- a/helpers/rm.py
+++ b/helpers/rm.py
@@ -9,10 +9,10 @@ def help(lines):
     matches = re.search(r"^rm: remove regular (?:empty )?file ‘(.+)’\?", lines[0])
     if matches:
         empty = re.search(r"^rm: remove regular empty file", lines[0])
-        after = [
+        response = [
             "The command you typed will delete the file `{}`".format(matches.group(1))
         ]
-        after[0] += " (which is empty anyway)." if empty else "."
-        after.append("If you wish to delete `{}`, type `y` and press return.".format(matches.group(1)))
-        after.append("Typing `n` and pressing return will cancel the operation.")
-        return (1, after)
+        response[0] += " (which is empty anyway)." if empty else "."
+        response.append("If you wish to delete `{}`, type `y` and press return.".format(matches.group(1)))
+        response.append("Typing `n` and pressing return will cancel the operation.")
+        return (1, response)

--- a/helpers/rm.py
+++ b/helpers/rm.py
@@ -15,4 +15,4 @@ def help(lines):
         after[0] += " (which is empty anyway)." if empty else "."
         after.append("If you wish to delete `{}`, type `y` and press return.".format(matches.group(1)))
         after.append("Typing `n` and pressing return will cancel the operation.")
-        return (lines[0:1], after)
+        return (1, after)


### PR DESCRIPTION
Addressing #51.

Each helper function now returns `(before, after)`, where `before` is the number of lines of the input (starting at `lines[0]`) that should be displayed. Any lines before `lines[0]` that weren't matched will also be displayed in the template.

If merged, this will (as of now) only change the web interface experience. To change the command-line experience as well, we'd then also have to change the `helpful.txt` template to display both `before` and `after` (with `after` in a different color, ideally), and then modify the `help50` script to not automatically display the output of `clang`, `make`, etc. and to not color all of the response from `help.cs50.net` (since `before` shouldn't be colored the same).

I didn't want to modify `helpful.txt` just yet, since otherwise students working right now would end up seeing two sets of error messages each time they run `help50`.