### PR TITLE
utf8 migration

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -18,11 +18,15 @@ manager.add_command('db', MigrateCommand)
 
 class Output(db.Model):
     __tablename__ = "outputs"
+    mysql_default_charset = "utf8",
+    mysql_collate = "utf8_general_ci"
     id = db.Column(db.BigInteger, primary_key=True, nullable=False, autoincrement=True)
     output = db.Column(db.Text)
 
 class Input(db.Model):
     __tablename__ = "inputs"
+    mysql_default_charset = "utf8",
+    mysql_collate =  "utf8_general_ci"
     id = db.Column(db.BigInteger, primary_key=True, nullable=False, autoincrement=True)
     cmd = db.Column(db.String(length=1024), nullable=True)
     script = db.Column(db.Text, nullable=False)

--- a/migrations/versions/e608cba71fc1_.py
+++ b/migrations/versions/e608cba71fc1_.py
@@ -1,0 +1,27 @@
+"""empty message
+
+Revision ID: e608cba71fc1
+Revises: 3b25e13c81bf
+Create Date: 2016-09-10 13:56:11.228559
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'e608cba71fc1'
+down_revision = '3b25e13c81bf'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    # http://stackoverflow.com/a/28369544
+    conn = op.get_bind()
+    conn.execute(sa.sql.text('ALTER TABLE alembic_version CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci'))
+    conn.execute(sa.sql.text('ALTER TABLE inputs CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci'))
+    conn.execute(sa.sql.text('ALTER TABLE outputs CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci'))
+    op.create_index(op.f('ix_inputs_reviewed'), 'inputs', ['reviewed'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_inputs_reviewed'), table_name='inputs')

--- a/model.py
+++ b/model.py
@@ -21,7 +21,11 @@ def log(cmd, username, script, output):
         output_id = help_out.id
     help_in = Input(cmd=cmd, username=username, script=script, output_id=output_id, created=datetime.utcnow())
     session.add(help_in)
-    session.commit()
+    try:
+        session.commit()
+    except:
+        session.rollback()
+        raise
 
 # gets unreviewed inputs with no output
 def unreviewed_matchless():
@@ -32,4 +36,8 @@ def mark_reviewed(input_id):
     row = session.query(Input).filter(Input.id==input_id).first()
     if (row != None):
         row.reviewed = True
-    session.commit()
+    try:
+        session.commit()
+    except:
+        session.rollback()
+        raise


### PR DESCRIPTION
Addressing #56, changes the default charset of the database to `utf8`. Alembic seems to have a known issue where certain changes [aren't detected](https://bitbucket.org/zzzeek/alembic/issues/180/detect-changes-in-type-parameters), so I had to manually add some lines to the migration file (source in comments).

I also found a recommendation in the SQLAlchemy [documentation](http://docs.sqlalchemy.org/en/latest/faq/sessions.html#this-session-s-transaction-has-been-rolled-back-due-to-a-previous-exception-during-flush-or-similar) to call `session.rollback()` if a database operation fails, so that the application doesn't continue trying to execute the failing operation in future operations. This should make it so that, if for some reason a user runs into a failed input, subsequent users aren't affected.