### PR TITLE
Matcher for "result of comparison against a string literal is unspecified"

### DIFF
--- a/helpers/clang.py
+++ b/helpers/clang.py
@@ -372,9 +372,10 @@ def help(lines):
     matches = re.search(r"^([^:]+):(\d+):\d+: (?:warning|error): result of comparison against a string literal is unspecified", lines[0])
     if matches:
         response = [
+            "You seem to be trying to compare two strings on line {} of `{}`".format(matches.group(2), matches.group(1)),
             "You can't compare two strings the same way you would compare two numbers (with `<`, `>`, etc.).",
             "Did you mean to compare two characters instead? If so, try using single quotation marks around characters instead of double quotation marks.",
-            "If you need to compare two strings, try using the `strcmp` function declared in `<string.h>`."
+            "If you need to compare two strings, try using the `strcmp` function declared in `string.h`."
         ]
         if len(lines) >= 2:
             return (2, response)

--- a/helpers/clang.py
+++ b/helpers/clang.py
@@ -366,6 +366,22 @@ def help(lines):
     
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
+    # foo.c:6:14: error: result of comparison against a string literal is unspecified (use strncmp instead) [-Werror,-Wstring-compare]
+    #     if (word < "twenty-eight")
+    #              ^ ~~~~~~~~~~~~~~
+    matches = re.search(r"^([^:]+):(\d+):\d+: (?:warning|error): result of comparison against a string literal is unspecified", lines[0])
+    if matches:
+        response = [
+            "You can't compare two strings the same way you would compare two numbers (with `<`, `>`, etc.).",
+            "Did you mean to compare two characters instead? If so, try using single quotation marks around characters instead of double quotation marks.",
+            "If you need to compare two strings, try using the `strcmp` function declared in `<string.h>`."
+        ]
+        if len(lines) >= 2:
+            return (2, response)
+        return (1, response)
+    
+    # $ clang foo.c
+    # /tmp/foo-1ce1b9.o: In function `main':
     # foo.c:3:1: error: type specifier missing, defaults to 'int' [-Werror,-Wimplicit-int]
     # square (int x) {
     # ^

--- a/helpers/clang.py
+++ b/helpers/clang.py
@@ -253,6 +253,20 @@ def help(lines):
         if matches:
             response = ["The first argument to `{}` on line {} of `{}` should be a double-quoted string.".format(matches.group(1), line, file)]
             return (2, response)
+        
+    # $ clang foo.c
+    # /tmp/foo-1ce1b9.o: In function `main':
+    # foo.c:12:15: error: if statement has empty body [-Werror,-Wempty-body]
+    #   if (n > 0);
+    #             ^
+    matches = re.search(r"^([^:]+):(\d+):\d+: (?:warning|error): (if statement|while loop|for loop) has empty body", lines[0])
+    if matches:
+        response = [
+            "Try removing the semicolon directly after the closing parentheses of the `{}` on line {} of `{}`.".format(matches.group(3),matches.group(2), matches.group(1))
+        ]
+        if len(lines) >= 2 and re.search(r"if\s*\(", lines[1]):
+            return (2, response)
+        return (1, response)
 
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
@@ -442,19 +456,5 @@ def help(lines):
             "Be sure to assign a value to `{}` before trying to access its value.".format(matches.group(3))
         ]
         if len(lines) >= 2 and re.search(matches.group(3), lines[1]):
-            return (2, response)
-        return (1, response)
-    
-    # $ clang foo.c
-    # /tmp/foo-1ce1b9.o: In function `main':
-    # foo.c:12:15: error: if statement has empty body [-Werror,-Wempty-body]
-    #   if (n > 0);
-    #             ^
-    matches = re.search(r"^([^:]+):(\d+):\d+: (?:warning|error): (if statement|while loop|for loop) has empty body", lines[0])
-    if matches:
-        response = [
-            "Try removing the semicolon directly after the closing parentheses of the `{}` on line {} of `{}`.".format(matches.group(3),matches.group(2), matches.group(1))
-        ]
-        if len(lines) >= 2 and re.search(r"if\s*\(", lines[1]):
             return (2, response)
         return (1, response)


### PR DESCRIPTION
Addressing #62, which appears in `/review` inputs `227` and `2139`.