### PR TITLE
a.out helpers

### DIFF
--- a/helpers/a.py
+++ b/helpers/a.py
@@ -18,10 +18,9 @@ def help(lines):
     if matches:
         response = [
             "Looks like your program is trying to access areas of memory that it isn't supposed to access.",
-            "There are many causes for segmentation faults, but you may want to consider:",
-            "Are you trying to access an element of an array beyond the size of the array?",
-            "Are you taking care to only dereference a pointer after you've initialized it (perhaps with `malloc`)?",
-            "Have you checked that any pointers you're dereferencing aren't NULL?",
-            "Are you trying to dereference a pointer after you've freed it?"
+            "Are you accessing an element of an array beyond the size of the array?",
+            "Are you dereferencing a pointer that you haven't initialized?",
+            "Are you dereferencing a pointer whose value is `NULL`?",
+            "Are you dereferencing a pointer after you've freed it?"
         ]
         return (1, response)

--- a/helpers/aout.py
+++ b/helpers/aout.py
@@ -1,0 +1,27 @@
+import re
+def help(lines):
+    
+    # $ ./a.out
+    # Floating point exception
+    matches = re.match("Floating point exception", lines[0])
+    if matches:
+        response = [
+            "Looks like somewhere in your program, you're trying to divide a number by 0.",
+            "Check to see where in your program you're using the `/` or `%` operators, and be sure you never divide by 0 or calculate a number modulo 0.",
+            "If still unsure of where the problem is, stepping through your code with `debug50` may be helpful!"
+        ]
+        return (1, response)
+    
+    # $ ./a.out
+    # Segmentation fault
+    matches = re.match("Segmentation fault", lines[0])
+    if matches:
+        response = [
+            "Looks like your program is trying to access areas of memory that it isn't supposed to access.",
+            "There are many causes for segmentation faults, but you may want to consider:",
+            "Are you trying to access an element of an array beyond the size of the array?",
+            "Are you taking care to only dereference a pointer after you've initialized it (perhaps with `malloc`)?",
+            "Have you checked that any pointers you're dereferencing aren't NULL?",
+            "Are you trying to dereference a pointer after you've freed it?"
+        ]
+        return (1, response)


### PR DESCRIPTION
Addressing #58 and #60.

The name `a.out.py` ran into trouble when trying to import it into `application.py` because Python uses the `.` as a way to separate modules.

Tentatively renamed to `aout.py`, which I'm not convinced is the most elegant name for the file, thoughts on anything better?