### PR TITLE
Match errors with "match" instead of "re.search"

### DIFF
--- a/helpers/clang.py
+++ b/helpers/clang.py
@@ -63,7 +63,7 @@ def help(lines):
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
     # foo.c:7:1: error: control may reach end of non-void function [-Werror,-Wreturn-type]
-    matches = match(r"control (may )?reach(es)? end of non-void function", lines[0], match_warning=True)
+    matches = match(r"control (may )?reach(es)? end of non-void function", lines[0])
     if matches:
         response = ["Ensure that your function will always return a value. If your function is not meant to return a value, try changing its return type to `void`."]
         return (1, response)
@@ -73,7 +73,7 @@ def help(lines):
     # foo.c:5:29: error: data argument not used by format string [-Werror,-Wformat-extra-args]
     #    printf("%d %d", 27, 28, 29);
     #           ~~~~~~~          ^
-    matches = match(r"data argument not used by format string", lines[0], match_warning=True)
+    matches = match(r"data argument not used by format string", lines[0])
     if matches:
         response = [
             "You have more arguments in your formatted string on line {} of `{}` than you have format codes.".format(matches.group(2), matches.group(1)),
@@ -95,7 +95,7 @@ def help(lines):
     # foo.c:5:20: error: declaration shadows a local variable [-Werror,-Wshadow]
     #    for (int i = 0, i < 28, i++)
     #                    ^
-    matches = match(r"declaration shadows a local variable", lines[0], match_warning=True)
+    matches = match(r"declaration shadows a local variable", lines[0])
     if matches:
         response = [
             "On line {} of `{}`, it seems that you're trying to create a new variable that has already been created.".format(matches.group(2), matches.group(1))
@@ -177,7 +177,7 @@ def help(lines):
     # foo.c:6:8: error: expected '(' after 'if'
     #     if x == 28
     #        ^
-    matches = match(r"expected '\(' after 'if'", lines[0], match_warning=True)
+    matches = match(r"expected '\(' after 'if'", lines[0])
     if matches:
         response = [
             "In your `if` statement on line {} of `{}`, be sure that you're enclosing the condition you're testing within parentheses.".format(matches.group(2), matches.group(1))
@@ -251,7 +251,7 @@ def help(lines):
     # foo.c:6:16: error: expression result unused [-Werror,-Wunused-value]
     # n*12;
     #  ^ 1 error generated.
-    matches = match(r"expression result unused", lines[0], match_warning=True)
+    matches = match(r"expression result unused", lines[0])
     if matches:
         response = [
             "On line {} of `{}` you are performing an operation, but not saving the result.".format(matches.group(2), matches.group(1)),
@@ -264,7 +264,7 @@ def help(lines):
     # foo.c:1:19: error: extra tokens at end of #include directive [-Werror,-Wextra-tokens]
     # #include <stdio.h>;
     #                   ^
-    matches = match(r"extra tokens at end of #include directive", lines[0], match_warning=True)
+    matches = match(r"extra tokens at end of #include directive", lines[0])
     if matches:
         response = [
             "You seem to have an error in `{}` on line {}.".format(matches.group(1), matches.group(2)),
@@ -284,7 +284,7 @@ def help(lines):
     # foo.c:1:10: fatal error: 'studio.h' file not found
     # #include <studio.h>
     #          ^
-    matches = match(r"'(.*)' file not found", lines[0], fatal_error=True)
+    matches = match(r"'(.*)' file not found", lines[0])
     if matches:
         response = [
             "Looks like you're trying to `#include` a file (`{}`) on line {} of `{}` which does not exist.".format(matches.group(3), matches.group(2), matches.group(1))
@@ -316,7 +316,7 @@ def help(lines):
     # foo.c:12:15: error: if statement has empty body [-Werror,-Wempty-body]
     #   if (n > 0);
     #             ^
-    matches = match(r"(if statement|while loop|for loop) has empty body", lines[0], match_warning=True)
+    matches = match(r"(if statement|while loop|for loop) has empty body", lines[0])
     if matches:
         response = [
             "Try removing the semicolon directly after the closing parentheses of the `{}` on line {} of `{}`.".format(matches.group(3),matches.group(2), matches.group(1))
@@ -330,7 +330,7 @@ def help(lines):
     # foo.c:5:12: error: implicit declaration of function 'get_int' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
     #    int x = get_int();
     #            ^
-    matches = match(r"implicit declaration of function '([^']+)' is invalid", lines[0], match_warning=True)
+    matches = match(r"implicit declaration of function '([^']+)' is invalid", lines[0])
     if matches:
         response = [
             "You seem to have an error in `{}` on line {}.".format(matches.group(1), matches.group(2)),
@@ -355,9 +355,9 @@ def help(lines):
     #    ^
     matches = match(r"implicitly declaring library function '([^']+)'", lines[0])
     if matches:
-        if (matches.group(3) == "printf"):
+        if (matches.group(3) in ["printf"]):
             response = ["Did you forget to `#include <stdio.h>` (in which `printf` is declared) atop your file?"]
-        elif (matches.group(3) == "malloc"):
+        elif (matches.group(3) in ["malloc"]):
             response = ["Did you forget to `#include <stdlib.h>` (in which `malloc` is declared) atop your file?"]
         else:
             response = ["Did you forget to `#include` the header file in which `{}` is declared atop your file?".format(matches.group(3))]
@@ -371,7 +371,7 @@ def help(lines):
     #       [-Werror,-Wint-conversion]
     #    int x = "28";
     #        ^   ~~~~
-    matches = match(r"incompatible ([^']+) to ([^']+) conversion", lines[0])
+    matches = match(r"incompatible (.+) to (.+) conversion", lines[0])
     if matches:
         response = [
             "By \"incompatible conversion\", `clang` means that you are assigning a value to a variable of a different type on line {} of `{}`. Try ensuring that your value is of type `{}`.".format(matches.group(2), matches.group(1), matches.group(4))
@@ -386,10 +386,10 @@ def help(lines):
     #    printf("%d\n", "hello!");
     #            ~~     ^~~~~~~~
     #            %s
-    matches = match(r"format specifies type '[^:]+' but the argument has type '[^:]+'", lines[0], match_warning=True)
+    matches = match(r"format specifies type '[^:]+' but the argument has type '[^:]+'", lines[0])
     if matches:
         response = [
-            "Be sure to use the correct format code (%i for integers, %f for floating point values, %s for strings) in your string format statement on line {} of `{}`.".format(matches.group(2), matches.group(1))
+            "Be sure to use the correct format code (%i for integers, %f for floating-point values, %s for strings) in your string format statement on line {} of `{}`.".format(matches.group(2), matches.group(1))
         ]
         if len(lines) >= 3 and re.search(r"\^", lines[2]):
             if len(lines) >= 4 and re.search(r"%", lines[3]):
@@ -436,7 +436,7 @@ def help(lines):
     # foo.c:5:16: error: more '%' conversions than data arguments [-Werror,-Wformat]
     #    printf("%d %d\n", 28);
     #               ~^
-    matches = match(r"more '%' conversions than data arguments", lines[0], match_warning=True)
+    matches = match(r"more '%' conversions than data arguments", lines[0])
     if matches:
         response = [
             "You have too many format codes (e.g. %i or %s) in your formatted string on line {} of `{}`.".format(matches.group(2), matches.group(1)),
@@ -452,7 +452,7 @@ def help(lines):
     # foo.c:1:10: error: multiple unsequenced modifications to 'space' [-Werror,-Wunsequenced]
     #  space = space--;
     #        ~      ^
-    matches = match(r"multiple unsequenced modifications to '(.*)'", lines[0], match_warning=True)
+    matches = match(r"multiple unsequenced modifications to '(.*)'", lines[0])
     if matches:
         variable = matches.group(3)
         response = [
@@ -470,7 +470,7 @@ def help(lines):
     # foo.c:6:14: error: result of comparison against a string literal is unspecified (use strncmp instead) [-Werror,-Wstring-compare]
     #     if (word < "twenty-eight")
     #              ^ ~~~~~~~~~~~~~~
-    matches = match(r"result of comparison against a string literal is unspecified", lines[0], match_warning=True)
+    matches = match(r"result of comparison against a string literal is unspecified", lines[0])
     if matches:
         response = [
             "You seem to be trying to compare two strings on line {} of `{}`".format(matches.group(2), matches.group(1)),
@@ -487,7 +487,7 @@ def help(lines):
     # foo.c:3:1: error: type specifier missing, defaults to 'int' [-Werror,-Wimplicit-int]
     # square (int x) {
     # ^
-    matches = match(r"type specifier missing, defaults to 'int'", lines[0], match_warning=True)
+    matches = match(r"type specifier missing, defaults to 'int'", lines[0])
     if matches:
         response = [
             "Looks like you're trying to declare a function on line {} of `{}`.".format(matches.group(2), matches.group(1)),
@@ -502,7 +502,7 @@ def help(lines):
     # foo.c:6:10: error: using the result of an assignment as a condition without parentheses [-Werror,-Wparentheses]
     #    if (x = 28)
     #        ~~^~~~
-    matches = match(r"using the result of an assignment as a condition without parentheses", lines[0], match_warning=True)
+    matches = match(r"using the result of an assignment as a condition without parentheses", lines[0])
     if matches:
         response = [
             "When checking for equality in the condition on line {} of `{}`, try using a double equals sign (`==`) instead of a single equals sign (`=`).".format(matches.group(2), matches.group(1))
@@ -565,7 +565,7 @@ def help(lines):
     # foo.c:6:9: error: unused variable 'x' [-Werror,-Wunused-variable]
     #     int x = 28;
     #         ^
-    matches = match(r"unused variable '([^']+)'", lines[0], match_warning=True)
+    matches = match(r"unused variable '([^']+)'", lines[0])
     if matches:
         response = [
             "It seems that the variable `{}` (delcared on line {} of `{}`) is never used in your program. Try either removing it altogether or using it.".format(matches.group(3), matches.group(2), matches.group(1))
@@ -577,7 +577,7 @@ def help(lines):
     # foo.c:6:20: error: variable 'x' is uninitialized when used here [-Werror,-Wuninitialized]
     #     printf("%d\n", x);
     #                    ^
-    matches = match(r"variable '(.*)' is uninitialized when used here", lines[0], match_warning=True)
+    matches = match(r"variable '(.*)' is uninitialized when used here", lines[0])
     if matches:
         response = [
             "It looks like you're trying to use the variable `{}` on line {} of `{}`.".format(matches.group(3), matches.group(2), matches.group(1)),
@@ -588,13 +588,12 @@ def help(lines):
             return (2, response)
         return (1, response)
 
-def match(expression, line, match_warning=False, fatal_error=False, raw=False):
-    error = "error"
-    if match_warning:
-        error = "(?:warning|error)"
-    elif fatal_error:
-        error = "fatal error"
-    query = r"^([^:]+):(\d+):\d+: " + error + r": " + expression
+# Performs a regular-expression match on a particular clang error or warning message.
+# The first capture group is the filename associated with the message.
+# The second capture group is the line number associated with the message.
+# set raw=True to search for a message that doesn't follow clang's typical error output format.
+def match(expression, line, raw=False):
+    query = r"^([^:]+):(\d+):\d+: (?:warning|(?:fatal )?error): " + expression
     if raw:
         query = expression
     return re.search(query, line)

--- a/helpers/clang.py
+++ b/helpers/clang.py
@@ -255,7 +255,7 @@ def help(lines):
     if matches:
         response = [
             "On line {} of `{}` you are performing an operation, but not saving the result.".format(matches.group(2), matches.group(1)),
-            "Try storing the result in a variable."
+            "Did you mean to print or store the result in a variable?"
         ]
         return (1, response)
 

--- a/helpers/clang.py
+++ b/helpers/clang.py
@@ -5,7 +5,7 @@ def help(lines):
 
     # $ clang foo.c
     # foo.c:13:25: error: adding 'int' to a string does not append to the string [-Werror,-Wstring-plus-int]
-    matches = re.search(r"^([^:]+):(\d+):\d+: error: adding '(.+)' to a string does not append to the string", lines[0])
+    matches = match(r"adding '(.+)' to a string does not append to the string", lines[0])
     if matches:
         response = ["Careful, you can't concatenate values and strings in C using the `+` operator, as you seem to be trying to do on line {} of `{}`.".format(matches.group(2), matches.group(1))]
         if len(lines) >= 2 and re.search(r"printf\s*\(", lines[1]):
@@ -17,7 +17,7 @@ def help(lines):
     # foo.c:6:21: error: array subscript is not an integer
     #     printf("%i\n", x["28"]);
     #                     ^~~~~
-    matches = re.search(r"^([^:]+):(\d+):\d+: error: array subscript is not an integer", lines[0])
+    matches = match(r"array subscript is not an integer", lines[0])
     if matches:
         array = var_extract(lines[1:3], left_aligned=False)
         index = tilde_extract(lines[1:3])
@@ -41,7 +41,7 @@ def help(lines):
     # foo.c:3:12: error: conflicting types for 'round'
     # int round(int n);
     #     ^
-    matches = re.search(r"^([^:]+):(\d+):\d+: error: conflicting types for '(.*)'", lines[0])
+    matches = match(r"conflicting types for '(.*)'", lines[0])
     if matches:
         response = [
             "Looks like you're redeclaring the function `{}`, but with a different return type on line {} of `{}`.".format(matches.group(3), matches.group(2), matches.group(1))
@@ -63,7 +63,7 @@ def help(lines):
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
     # foo.c:7:1: error: control may reach end of non-void function [-Werror,-Wreturn-type]
-    matches = re.search(r"control (may)?reach(es)? end of non-void function", lines[0])
+    matches = match(r"control (may )?reach(es)? end of non-void function", lines[0], match_warning=True)
     if matches:
         response = ["Ensure that your function will always return a value. If your function is not meant to return a value, try changing its return type to `void`."]
         return (1, response)
@@ -73,7 +73,7 @@ def help(lines):
     # foo.c:5:29: error: data argument not used by format string [-Werror,-Wformat-extra-args]
     #    printf("%d %d", 27, 28, 29);
     #           ~~~~~~~          ^
-    matches = re.search(r"^([^:]+):(\d+):\d+: (?:warning|error): data argument not used by format string", lines[0])
+    matches = match(r"data argument not used by format string", lines[0], match_warning=True)
     if matches:
         response = [
             "You have more arguments in your formatted string on line {} of `{}` than you have format codes.".format(matches.group(2), matches.group(1)),
@@ -95,7 +95,7 @@ def help(lines):
     # foo.c:5:20: error: declaration shadows a local variable [-Werror,-Wshadow]
     #    for (int i = 0, i < 28, i++)
     #                    ^
-    matches = re.search(r"^([^:]+):(\d+):\d+: (?:warning|error): declaration shadows a local variable", lines[0])
+    matches = match(r"declaration shadows a local variable", lines[0], match_warning=True)
     if matches:
         response = [
             "On line {} of `{}`, it seems that you're trying to create a new variable that has already been created.".format(matches.group(2), matches.group(1))
@@ -137,7 +137,7 @@ def help(lines):
     # foo.c:5:1: error: expected identifier or '('
     # do
     # ^
-    matches = re.search(r"^([^:]+):(\d+):\d+: error: expected identifier or '\('", lines[0])
+    matches = match(r"expected identifier or '\('", lines[0])
     if matches:
         response = [
             "Looks like `clang` is having some trouble understanding where your functions start and end in your code.",
@@ -152,7 +152,7 @@ def help(lines):
     # foo.c:3:12: error: expected parameter declarator
     # int square(28);
     #            ^
-    matches = re.search(r"^([^:]+):(\d+):\d+: error: expected parameter declarator", lines[0])
+    matches = match(r"expected parameter declarator", lines[0])
     if matches:
         response = [
             "If you're trying to call a function on line {} of `{}`, be sure that you're calling it inside of curly braces within a function. Also check that the function's header (the line introducing the function's name) doesn't end in a semicolon.".format(matches.group(2), matches.group(1)),
@@ -167,7 +167,7 @@ def help(lines):
     # foo.c:9:2: error: expected '}'
     # }
     #  ^
-    matches = re.search(r"error: expected '}'", lines[0])
+    matches = match(r"expected '}'", lines[0])
     if matches:
         response = ["Make sure that all opening brace symbols `{` are matched with a closing brace `}`."]
         return (1, response)
@@ -177,7 +177,7 @@ def help(lines):
     # foo.c:6:8: error: expected '(' after 'if'
     #     if x == 28
     #        ^
-    matches = re.search(r"^([^:]+):(\d+):\d+: (?:warning|error): expected '\(' after 'if'", lines[0])
+    matches = match(r"expected '\(' after 'if'", lines[0], match_warning=True)
     if matches:
         response = [
             "In your `if` statement on line {} of `{}`, be sure that you're enclosing the condition you're testing within parentheses.".format(matches.group(2), matches.group(1))
@@ -191,7 +191,7 @@ def help(lines):
     # foo.c:6:1: error: expected ')'
     # }
     # ^
-    matches = re.search(r"^([^:]+):(\d+):\d+: error: expected '\)'", lines[0])
+    matches = match(r"expected '\)'", lines[0])
     if matches:
         # assume that the line number for the matching ')' is the line that generated the error
         match_line = matches.group(2)
@@ -216,7 +216,7 @@ def help(lines):
     #    printf("hello, world!")
     #                           ^
     #                           ;
-    matches = re.search(r"^([^:]+):(\d+):\d+: error: expected ';' (?:after expression|at end of declaration|after do\/while statement)", lines[0])
+    matches = match(r"expected ';' (?:after expression|at end of declaration|after do\/while statement)", lines[0])
     if matches:
         response = ["Try including a semicolon at the end of line {} of `{}`.".format(matches.group(2), matches.group(1))]
         if len(lines) >= 3 and re.search(r"^\s*\^$", lines[2]):
@@ -230,7 +230,7 @@ def help(lines):
     # foo.c:5:22: error: expected ';' in 'for' statement specifier
     #    for (int i = 0, i < 28, i++)
     #                      ^
-    matches = re.search(r"^[^:]+:(\d+):\d+: error: expected ';' in 'for' statement specifier", lines[0])
+    matches = match(r"expected ';' in 'for' statement specifier", lines[0])
     if matches:
         response = ["Be sure to separate the three components of the 'for' loop on line {} with semicolons.".format(matches.group(1))]
         if len(lines) >= 2 and re.search(r"for\s*\(", lines[1]):
@@ -240,7 +240,7 @@ def help(lines):
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
     # foo.c:28:28: error: expected expression
-    matches = re.search(r"^([^:]+):(\d+):\d+: error: expected expression", lines[0])
+    matches = match(r"expected expression", lines[0])
     if matches:
         response = [
             "Not quite sure how to help, but focus your attention on line {} of `{}`!".format(matches.group(2), matches.group(1))
@@ -251,7 +251,7 @@ def help(lines):
     # foo.c:6:16: error: expression result unused [-Werror,-Wunused-value]
     # n*12;
     #  ^ 1 error generated.
-    matches = re.search(r"^([^:]+):(\d+):\d+: (?:warning|error): expression result unused", lines[0])
+    matches = match(r"expression result unused", lines[0], match_warning=True)
     if matches:
         response = [
             "On line {} of `{}` you are doing an operation, but not saving the result.".format(matches.group(2), matches.group(1)),
@@ -264,10 +264,10 @@ def help(lines):
     # foo.c:1:19: error: extra tokens at end of #include directive [-Werror,-Wextra-tokens]
     # #include <stdio.h>;
     #                   ^
-    matches = re.search(r"^([^:]+):(\d+):(\d+): (?:warning|error): extra tokens at end of #include directive", lines[0])
+    matches = match(r"extra tokens at end of #include directive", lines[0], match_warning=True)
     if matches:
         response = [
-            "You seem to have an error in `{}` on line {} at character {}.".format(matches.group(1), matches.group(2), matches.group(3)),
+            "You seem to have an error in `{}` on line {}.".format(matches.group(1), matches.group(2)),
             "By \"extra tokens\", `clang` means that you have one or more extra characters on that line that you shouldn't."
         ]
         if len(lines) >= 3 and re.search(r"^\s*\^", lines[2]):
@@ -284,7 +284,7 @@ def help(lines):
     # foo.c:1:10: fatal error: 'studio.h' file not found
     # #include <studio.h>
     #          ^
-    matches = re.search(r"^([^:]+):(\d+):\d+: fatal error: '(.*)' file not found", lines[0])
+    matches = match(r"'(.*)' file not found", lines[0], fatal_error=True)
     if matches:
         response = [
             "Looks like you're trying to `#include` a file (`{}`) on line {} of `{}` which does not exist.".format(matches.group(3), matches.group(2), matches.group(1))
@@ -302,7 +302,7 @@ def help(lines):
     # foo.c:6:16: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
     # printf(c);
     # ^ 1 error generated.
-    matches = re.search(r"^([^:]+):(\d+):\d+: error: format string is not a string literal", lines[0])
+    matches = match(r"format string is not a string literal", lines[0])
     if matches and len(lines) >= 3 and re.search(r"^\s*\^", lines[2]):
         file, line = matches.groups()
         matches = re.search(r"^(.?printf|.?scanf)\s*\(", lines[1][lines[2].index("^"):])
@@ -316,7 +316,7 @@ def help(lines):
     # foo.c:12:15: error: if statement has empty body [-Werror,-Wempty-body]
     #   if (n > 0);
     #             ^
-    matches = re.search(r"^([^:]+):(\d+):\d+: (?:warning|error): (if statement|while loop|for loop) has empty body", lines[0])
+    matches = match(r"(if statement|while loop|for loop) has empty body", lines[0], match_warning=True)
     if matches:
         response = [
             "Try removing the semicolon directly after the closing parentheses of the `{}` on line {} of `{}`.".format(matches.group(3),matches.group(2), matches.group(1))
@@ -330,19 +330,19 @@ def help(lines):
     # foo.c:5:12: error: implicit declaration of function 'get_int' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
     #    int x = get_int();
     #            ^
-    matches = re.search(r"^([^:]+):(\d+):(\d+): (?:warning|error): implicit declaration of function '([^']+)' is invalid", lines[0])
+    matches = match(r"implicit declaration of function '([^']+)' is invalid", lines[0], match_warning=True)
     if matches:
         response = [
-            "You seem to have an error in `{}` on line {} at character {}.".format(matches.group(1), matches.group(2), matches.group(3)),
-            "By \"implicit declaration of function '{}'\", `clang` means that it doesn't recognize `{}`.".format(matches.group(4), matches.group(4))
+            "You seem to have an error in `{}` on line {}.".format(matches.group(1), matches.group(2)),
+            "By \"implicit declaration of function '{}'\", `clang` means that it doesn't recognize `{}`.".format(matches.group(3), matches.group(3))
         ]
-        if matches.group(4) in ["eprintf", "get_char", "get_double", "get_float", "get_int", "get_long", "get_long_long", "get_string", "GetChar", "GetDouble", "GetFloat", "GetInt", "GetLong", "GetLongLong", "GetString"]:
-            response.append("Did you forget to `#include <cs50.h>` (in which `{}` is declared) atop your file?".format(matches.group(4)))
+        if matches.group(3) in ["eprintf", "get_char", "get_double", "get_float", "get_int", "get_long", "get_long_long", "get_string", "GetChar", "GetDouble", "GetFloat", "GetInt", "GetLong", "GetLongLong", "GetString"]:
+            response.append("Did you forget to `#include <cs50.h>` (in which `{}` is declared) atop your file?".format(matches.group(3)))
         else:
-            response.append("Did you forget to `#include` the header file in which `{}` is declared atop your file?".format(matches.group(4)))
-            response.append("Did you forget to declare a prototype for `{}` atop `{}`?".format(matches.group(4), matches.group(1)))
+            response.append("Did you forget to `#include` the header file in which `{}` is declared atop your file?".format(matches.group(3)))
+            response.append("Did you forget to declare a prototype for `{}` atop `{}`?".format(matches.group(3), matches.group(1)))
 
-        if len(lines) >= 2 and re.search(matches.group(4), lines[1]):
+        if len(lines) >= 2 and re.search(matches.group(3), lines[1]):
             return (2, response)
         return (1, response)
 
@@ -351,14 +351,14 @@ def help(lines):
     # foo.c:3:4: error: implicitly declaring library function 'printf' with type 'int (const char *, ...)' [-Werror]
     #    printf("hello, world!");
     #    ^
-    matches = re.search(r"implicitly declaring library function '([^']+)'", lines[0])
+    matches = match(r"implicitly declaring library function '([^']+)'", lines[0])
     if matches:
-        if (matches.group(1) == "printf"):
+        if (matches.group(3) == "printf"):
             response = ["Did you forget to `#include <stdio.h>` (in which `printf` is declared) atop your file?"]
-        elif (matches.group(1) == "malloc"):
+        elif (matches.group(3) == "malloc"):
             response = ["Did you forget to `#include <stdlib.h>` (in which `malloc` is declared) atop your file?"]
         else:
-            response = ["Did you forget to `#include` the header file in which `{}` is declared atop your file?".format(matches.group(1))]
+            response = ["Did you forget to `#include` the header file in which `{}` is declared atop your file?".format(matches.group(3))]
         if len(lines) >= 2 and re.search(r"printf\s*\(", lines[1]):
             return (2, response)
         return (1, response)
@@ -369,9 +369,11 @@ def help(lines):
     #       [-Werror,-Wint-conversion]
     #    int x = "28";
     #        ^   ~~~~
-    matches = re.search(r"incompatible ([^']+) to ([^']+) conversion", lines[0])
+    matches = match(r"incompatible ([^']+) to ([^']+) conversion", lines[0])
     if matches:
-        response = ["By \"incompatible conversion\", `clang` means that you are assigning a value to a variable of a different type. Try ensuring that your value is of type `{}`.".format(matches.group(2))]
+        response = [
+            "By \"incompatible conversion\", `clang` means that you are assigning a value to a variable of a different type on line {} of `{}`. Try ensuring that your value is of type `{}`.".format(matches.group(2), matches.group(1), matches.group(4))
+        ]
         if len(lines) >= 2 and re.search(r"=", lines[1]):
             return (2, response)
         return (1, response)
@@ -382,9 +384,11 @@ def help(lines):
     #    printf("%d\n", "hello!");
     #            ~~     ^~~~~~~~
     #            %s
-    matches = re.search(r"^[^:]+:(\d+):\d+: error: format specifies type '[^:]+' but the argument has type '[^:]+'", lines[0])
+    matches = match(r"format specifies type '[^:]+' but the argument has type '[^:]+'", lines[0], match_warning=True)
     if matches:
-        response = ["Be sure to use the correct format code (%i for integers, %f for floating point values, %s for strings) in your string format statement on line {}.".format(matches.group(1))]
+        response = [
+            "Be sure to use the correct format code (%i for integers, %f for floating point values, %s for strings) in your string format statement on line {} of `{}`.".format(matches.group(2), matches.group(1))
+        ]
         if len(lines) >= 3 and re.search(r"\^", lines[2]):
             if len(lines) >= 4 and re.search(r"%", lines[3]):
                 return (4, response)
@@ -396,9 +400,11 @@ def help(lines):
     # foo.c:1:2: error: invalid preprocessing directive
     # #incalude <stdio.h>
     #  ^
-    matches = re.search(r"^[^:]+:(\d+):\d+: error: invalid preprocessing directive", lines[0])
+    matches = match(r"invalid preprocessing directive", lines[0])
     if matches:
-        response = ["By \"invalid preprocesing directive\", `clang` means that you've used a preprocessor command on line {} (a command beginning with #) that is not recognized.".format(matches.group(1))]
+        response = [
+            "By \"invalid preprocesing directive\", `clang` means that you've used a preprocessor command on line {} (a command beginning with #) that is not recognized.".format(matches.group(1))
+        ]
         if len(lines) >= 2:
             directive = re.search(r"^([^' ]+)", lines[1])
             if directive:
@@ -412,7 +418,7 @@ def help(lines):
     # void main(void)
     # ^~~~
     # int
-    matches = re.search(r"^([^:]+):(\d+):\d+: error: 'main' must return 'int'", lines[0])
+    matches = match(r"'main' must return 'int'", lines[0])
     if matches:
         response = [
             "Your `main` function (declared on line {} of `{}`) must have a return type `int`.".format(matches.group(2), matches.group(1))
@@ -428,7 +434,7 @@ def help(lines):
     # foo.c:5:16: error: more '%' conversions than data arguments [-Werror,-Wformat]
     #    printf("%d %d\n", 28);
     #               ~^
-    matches = re.search(r"^([^:]+):(\d+):\d+: (?:warning|error): more '%' conversions than data arguments", lines[0])
+    matches = match(r"more '%' conversions than data arguments", lines[0], match_warning=True)
     if matches:
         response = [
             "You have too many format codes (e.g. %i or %s) in your formatted string on line {} of `{}`.".format(matches.group(2), matches.group(1)),
@@ -444,11 +450,11 @@ def help(lines):
     # foo.c:1:10: error: multiple unsequenced modifications to 'space' [-Werror,-Wunsequenced]
     #  space = space--;
     #        ~      ^
-    matches = re.search(r"^([^:]+):(\d+):\d+: (?:warning|error): multiple unsequenced modifications to '(.*)'", lines[0])
+    matches = match(r"multiple unsequenced modifications to '(.*)'", lines[0], match_warning=True)
     if matches:
         variable = matches.group(3)
         response = [
-            "Looks like you're changing the variable `{}`` multiple times in a row on line {} of `{}`.".format(variable, matches.group(2), matches.group(1))
+            "Looks like you're changing the variable `{}` multiple times in a row on line {} of `{}`.".format(variable, matches.group(2), matches.group(1))
         ]
         if len(lines) >= 2:
             matches = re.search(r".*(--|++)", lines[1])
@@ -462,7 +468,7 @@ def help(lines):
     # foo.c:6:14: error: result of comparison against a string literal is unspecified (use strncmp instead) [-Werror,-Wstring-compare]
     #     if (word < "twenty-eight")
     #              ^ ~~~~~~~~~~~~~~
-    matches = re.search(r"^([^:]+):(\d+):\d+: (?:warning|error): result of comparison against a string literal is unspecified", lines[0])
+    matches = match(r"result of comparison against a string literal is unspecified", lines[0], match_warning=True)
     if matches:
         response = [
             "You seem to be trying to compare two strings on line {} of `{}`".format(matches.group(2), matches.group(1)),
@@ -479,7 +485,7 @@ def help(lines):
     # foo.c:3:1: error: type specifier missing, defaults to 'int' [-Werror,-Wimplicit-int]
     # square (int x) {
     # ^
-    matches = re.search(r"^([^:]+):(\d+):\d+: (?:warning|error): type specifier missing, defaults to 'int'", lines[0])
+    matches = match(r"type specifier missing, defaults to 'int'", lines[0], match_warning=True)
     if matches:
         response = [
             "Looks like you're trying to declare a function on line {} of `{}`.".format(matches.group(2), matches.group(1)),
@@ -494,9 +500,11 @@ def help(lines):
     # foo.c:6:10: error: using the result of an assignment as a condition without parentheses [-Werror,-Wparentheses]
     #    if (x = 28)
     #        ~~^~~~
-    matches = re.search(r"^[^:]+:(\d+):\d+: (?:warning|error): using the result of an assignment as a condition without parentheses", lines[0])
+    matches = match(r"using the result of an assignment as a condition without parentheses", lines[0], match_warning=True)
     if matches:
-        response = ["When checking for equality in the condition on line {}, try using a double equals sign (`==`) instead of a single equals sign (`=`).".format(matches.group(1))]
+        response = [
+            "When checking for equality in the condition on line {} of `{}`, try using a double equals sign (`==`) instead of a single equals sign (`=`).".format(matches.group(2), matches.group(1))
+        ]
         if len(lines) >= 2 and re.search(r"if\s*\(", lines[1]):
             return (2, response)
         return (1, response)
@@ -506,13 +514,15 @@ def help(lines):
     # foo.c:5:4: error: use of undeclared identifier 'x'
     #    x = 28;
     #    ^
-    matches = re.search(r"use of undeclared identifier '([^']+)'", lines[0])
+    matches = match(r"use of undeclared identifier '([^']+)'", lines[0])
     if matches:
-        response = ["By \"undeclared identifier,\" `clang` means you've used a name `{}` which hasn't been defined.".format(matches.group(1))]
-        if matches.group(1) in ["true", "false", "bool", "string"]:
-            response.append("Did you forget to `#include <cs50.h>` (in which `{}` is defined) atop your file?".format(matches.group(1)))
+        response = [
+            "By \"undeclared identifier,\" `clang` means you've used a name `{}` on line {} of `{}` which hasn't been defined.".format(matches.group(3), matches.group(2), matches.group(1))
+        ]
+        if matches.group(3) in ["true", "false", "bool", "string"]:
+            response.append("Did you forget to `#include <cs50.h>` (in which `{}` is defined) atop your file?".format(matches.group(3)))
         else:
-            response.append("If you mean to use `{}` as a variable, make sure to declare it by specifying its type, and check that the variable name is spelled correctly.".format(matches.group(1)))
+            response.append("If you mean to use `{}` as a variable, make sure to declare it by specifying its type, and check that the variable name is spelled correctly.".format(matches.group(3)))
         if len(lines) >= 2 and re.search(matches.group(1), lines[1]):
             return (2, response)
         return (1, response)
@@ -520,9 +530,12 @@ def help(lines):
     # $ clang foo.c
     # /tmp/foo-1ce1b9.o: In function `main':
     # foo.c:(.text+0x9): undefined reference to `get_int'
-    matches = re.search(r"undefined reference to `([^']+)'", lines[0])
+    matches = match(r"undefined reference to `([^']+)'", lines[0], raw=True)
     if matches:
-        response = ["By \"undefined reference,\" `clang` means that you've called a function, `{}`, that doesn't seem to be implemented. If that function has, in fact, been implemented, odds are you've forgotten to tell `clang` to \"link\" against the file that implements `{}`.".format(matches.group(1), matches.group(1))]
+        response = [
+            "By \"undefined reference,\" `clang` means that you've called a function, `{}`, that doesn't seem to be implemented.".format(matches.group(1)),
+            "If that function has, in fact, been implemented, odds are you've forgotten to tell `clang` to \"link\" against the file that implements `{}`.".format(matches.group(1))
+        ]
         if matches.group(1) in ["eprintf", "get_char", "get_double", "get_float", "get_int", "get_long", "get_long_long", "get_string"]:
             response.append("Did you forget to compile with `-lcs50` in order to link against against the CS50 Library, which implements `{}`?".format(matches.group(1)))
         elif matches.group(1) in ["GetChar", "GetDouble", "GetFloat", "GetInt", "GetLong", "GetLongLong", "GetString"]:
@@ -550,7 +563,7 @@ def help(lines):
     # foo.c:6:9: error: unused variable 'x' [-Werror,-Wunused-variable]
     #     int x = 28;
     #         ^
-    matches = match(r"unused variable '([^']+)'", lines[0])
+    matches = match(r"unused variable '([^']+)'", lines[0], match_warning=True)
     if matches:
         response = [
             "It seems that the variable `{}` (delcared on line {} of `{}`) is never used in your program. Try either removing it altogether or using it.".format(matches.group(3), matches.group(2), matches.group(1))
@@ -573,9 +586,13 @@ def help(lines):
             return (2, response)
         return (1, response)
 
-def match(expression, line, match_warning=False, fatal_error=False):
-    error = "error" if not fatal_error else "fatal error"
+def match(expression, line, match_warning=False, fatal_error=False, raw=False):
+    error = "error"
     if match_warning:
-        error = "(?:warning|" + error + ")"
-    query = r"^([^:]+):(\d+):\d+: " + error + ": " + expression
+        error = "(?:warning|error)"
+    elif fatal_error:
+        error = "fatal error"
+    query = r"^([^:]+):(\d+):\d+: " + error + r": " + expression
+    if raw:
+        query = expression
     return re.search(query, line)

--- a/helpers/clang.py
+++ b/helpers/clang.py
@@ -254,8 +254,8 @@ def help(lines):
     matches = match(r"expression result unused", lines[0], match_warning=True)
     if matches:
         response = [
-            "On line {} of `{}` you are doing an operation, but not saving the result.".format(matches.group(2), matches.group(1)),
-            "Try storing the result in a variable"
+            "On line {} of `{}` you are performing an operation, but not saving the result.".format(matches.group(2), matches.group(1)),
+            "Try storing the result in a variable."
         ]
         return (1, response)
 


### PR DESCRIPTION
Per our discussion earlier, I've written `match(expression, line)` in `clang.py`, which takes an error regular expression and a line to search on. `match` will by default search for a `clang` error line with that particular error message.

The `match_warning` optional argument will allows the matcher to match an `error` or a `warning`, the `fatal_error` optional argument specifies to search for `fatal error` instead of just `error`, and the `raw` optional argument is for when we're trying to match something that doesn't follow `clang`'s normal error output (like the linker error we match).

I went ahead and changed our existing matchers to use this format.