### PR TITLE
Special-cased `check`, `style`, and `submit`. Made detection of inter…

### DIFF
--- a/helpers/bash.py
+++ b/helpers/bash.py
@@ -1,15 +1,22 @@
 import re
 def help(lines):
 
-    # $ $ foo
+    # $ foo
     # bash: foo: command not found
     matches = re.search(r"^bash: (.+): command not found", lines[0])
     if matches:
-        response = [
-            "Are you sure `{}` exists?".format(matches.group(1)),
-            "Did you misspell `{}`?".format(matches.group(1)),
-            "Did you mean to execute `./{}`?".format(matches.group(1))
-        ]
+        if (matches.group(1) == "check"):
+            response = ["Did you mean to execute `check50`?"]
+        elif (matches.group(1) == "style"):
+            response = ["Did you mean to execute `style50`?"]
+        elif (matches.group(1) == "submit"):
+            response = ["Did you mean to execute `submit50`?"]
+        else:
+            response = [
+                "Are you sure `{}` exists?".format(matches.group(1)),
+                "Did you misspell `{}`?".format(matches.group(1)),
+                "Did you mean to execute `./{}`?".format(matches.group(1))
+            ]
         return (1, response)
 
     # $ cd foo
@@ -36,16 +43,14 @@ def help(lines):
     # bash: ./foo: Permission denied
     matches = re.search(r"^bash: .*?(([^/]+)\.([^/.]+)): Permission denied", lines[0])
     if matches:
-        response = [
-            "`{}` couldn't be executed.".format(matches.group(1))
-        ]
-        if (matches.group(3) == "c"):
+        response = ["`{}` couldn't be executed.".format(matches.group(1))]
+        if (matches.group(3).lower() == "c"):
             response.append("Did you mean to execute `./{}`?".format(matches.group(2)))
-        elif (matches.group(3) == "pl"):
+        elif (matches.group(3).lower() == "pl"):
             response.append("Did you mean to execute `perl {}`?".format(matches.group(1)))
-        elif (matches.group(3) == "php"):
+        elif (matches.group(3).lower() == "php"):
             response.append("Did you mean to execute `php {}`?".format(matches.group(1)))
-        elif (matches.group(3) == "rb"):
+        elif (matches.group(3).lower() == "rb"):
             response.append("Did you mean to execute `ruby {}`?".format(matches.group(1)))
         else:
             response.append("Did you remember to make `{}` \"executable\" with `chmod +x {}`?".format(matches.group(1), matches.group(1)))


### PR DESCRIPTION
* Special-cased `check`, `style`, and `submit`.
* Made detection of interpreted languages' file extensions case-insensitive.