### PR TITLE
Update clang match function

### DIFF
--- a/helpers/clang.py
+++ b/helpers/clang.py
@@ -1,4 +1,5 @@
 import re
+from collections import namedtuple
 from tools import *
 
 def help(lines):
@@ -774,4 +775,7 @@ def match(expression, line, raw=False):
     query = r"^([^:]+):(\d+):\d+: (?:warning|(?:fatal )?error): " + expression
     if raw:
         query = expression
-    return re.search(query, line)
+    matches = re.search(query, line)
+    if matches:
+        Match = namedtuple('Match', ['file', 'line', 'group'])
+        return Match(file=matches.group(1), line=matches.group(2), group=matches.groups()[2:])


### PR DESCRIPTION
Addressing #179 

In the old version of `match`:

- `matches.group(1)` was the filename
- `matches.group(2)` was the line number
- `matches.group(3)`, `matches.group(4)`, `matches.group(5)`, etc. were the first, second, and third matches requested by the argument to the `match` function.

In this version:

- `matches.file` is the filename
- `matches.line` is the line number
- `matches.group[0]`, `matches.group[1]`, `matches.group[2]`, etc. are the first, second, and third matches.

Given that `matches.group` is now a list (instead of a function), I opted for zero-indexing it, but if you think the semantics of `matches.group[1]` for the first group is nicer, that's a fairly simple change.