### PR TITLE
Update README to reflect before, after

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 To contribute a sample error message that `help50` does yet support, [open an issue](https://github.com/cs50/help50/issues) and provide, ideally, both the error message and the command (and code, if any) that triggered it, both formatted in Markdown like [code](https://guides.github.com/features/mastering-markdown/#syntax).
 
-Better yet, to contribute to a helper for `foo`, implement `helpers/foo.py` per the below, where `lines` will be an array of strings (i.e., lines of `stderr` and/or `stdout` potentially from `foo`) for which user needs help, `n` must be a number of `lines` that this helper has matched on, and `response` must be an array of strings that help user understand the first `n` lines of `lines`. Helper must return `None` if it does not recognize `lines[0]`. Only if helper recognizes `lines[0]` may it look at `lines[1:]`.
+Better yet, to contribute to a helper for `foo`, implement `helpers/foo.py` per the below, where `lines` will be an array of strings (i.e., lines of `stderr` and/or `stdout` potentially from `foo`) for which user needs help, `before` must be a subset of `lines` that this helper has matched on, and `after` must be an array of strings that help user understand `before`. Helper must return `None` if it does not recognize `lines[0]`. Only if helper recognizes `lines[0]` may it look at `lines[1:]`.
 
 ```python
 import re
@@ -10,7 +10,7 @@ def help(lines):
     ...
     # if helper recognizes lines[0]
         ...
-        return (n, response)
+        return (before, after)
 ```
 
 Here are [open issues](https://github.com/cs50/help50/issues) if you'd like to solve one or more!


### PR DESCRIPTION
Current version of the README still says helper functions should return `(n, response)`, updating it to reflect the latest return type.