### PR TITLE
Fix permission denied regex

### DIFF
--- a/helpers/bash.py
+++ b/helpers/bash.py
@@ -41,7 +41,7 @@ def help(lines):
 
     # $ ./foo
     # bash: ./foo: Permission denied
-    matches = re.search(r"^bash: .*?(([^/]+)\.([^/.]+)): Permission denied", lines[0])
+    matches = re.search(r"^bash: .*?(([^/]+?)\.?([^/.]*)): Permission denied", lines[0])
     if matches:
         response = ["`{}` couldn't be executed.".format(matches.group(1))]
         if (matches.group(3).lower() == "c"):


### PR DESCRIPTION
Addressing the "unable to help" message that came from 

```
bash: ./foo: Permission denied
```

Turns out this isn't a new issue at all, it's just a problem with the regex for the error that's been there since the beginning. The old regex would only match "permission denied" errors for `./foo.c`, `./foo.php`, etc. (with an extension), and wouldn't match `./foo`.

I fixed the regex, and now it should work for both `./foo` and `./foo.c`