### PR TITLE
Unescape HTML characters

### DIFF
--- a/application.py
+++ b/application.py
@@ -3,6 +3,7 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 import flask_migrate
 import helpers
+import html as HTML
 import manage
 import model
 import os
@@ -102,7 +103,7 @@ def bad_request(e):
 # ANSI filter
 @app.template_filter("ans")
 def ans(value):
-    return re.sub(r"`([^`]+)`", r"\033[1m\1\033[22m", value)
+    return re.sub(r"`([^`]+)`", r"\033[1m\1\033[22m", HTML.unescape(value))
 
 # HTML filter
 @app.template_filter("html")


### PR DESCRIPTION
While testing a separate issue, noticed that characters like `'` in `help50` were being turned into `&#39;` in help50's output, as per the below:

<img width="485" alt="screen shot 2016-09-28 at 1 27 55 pm" src="https://cloud.githubusercontent.com/assets/16066224/18925572/75a9bf68-8582-11e6-93c6-c89208cb0164.png">

Went into the `filter` that we use for `helpful.ans` and updated it to unescape the HTML characters. Before and after are shown below:

<img width="476" alt="screen shot 2016-09-28 at 1 48 41 pm" src="https://cloud.githubusercontent.com/assets/16066224/18925656/d15ec65a-8582-11e6-8383-f994a81e4d9f.png">
