### PR TITLE
Sorts /review entries based on similar "script" fields (descending frequency)

### DIFF
--- a/model.py
+++ b/model.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from flask_sqlalchemy import SQLAlchemy
+from fuzzywuzzy import fuzz
 from manage import Output, Input
 from pytz import timezone
 from sqlalchemy import create_engine
@@ -30,7 +31,62 @@ def log(cmd, username, script, output):
 
 # gets unreviewed inputs with no output
 def unreviewed_matchless():
-    return session.query(Input).filter(Input.output_id==None, Input.reviewed==False).order_by(Input.created).all()
+    # we're going to group together all similar results
+    counter = 0
+    result_map = {}
+
+    # grab all results from db
+    results = session.query(Input).filter(Input.output_id==None, Input.reviewed==False).order_by(Input.created).all()
+
+    for result in results:
+        # initialize dict with first grouping if none exists
+        if len(result_map.keys()) < 1:
+            result_map[counter] = [result]
+            counter += 1
+        else:
+            # for every fuzzy grouping we've created, do a fuzzy search on all entries
+            for k in result_map.keys():
+
+                # breaks out of this loop after enclosing loop if match was found
+                found = False
+
+                # check ratios from 80 to 40, step size of -10
+                for val in range(90, 49, -10):
+                    # the most valuable line is *usually* the second, so test that
+                    lines = result.script.split('\n')
+                    test_line = lines[1] if len(lines) > 1 else lines[0]
+
+                    ratios = []
+
+                    # split each script by newlines, taking the 1st as a heuristic usually (most info)
+                    for x in result_map[k]:
+                        k_lines = x.script.split('\n')
+                        k_test_line = k_lines[1] if len(k_lines) > 1 else k_lines[0]
+                        ratios.append(fuzz.ratio(test_line, k_lines))
+
+                    avg_ratio = sum(ratios) / len(ratios)
+
+                    # if our average ratio is below what we're checking, it's similar
+                    if avg_ratio >= val:
+                        result_map[k].append(result)
+                        found = True
+                        break
+
+                if found:
+                    break
+
+            # create new grouping if we were unsuccessful
+            result_map[counter] = [result]
+            counter += 1
+
+    # get all lists into one list we can sort it in reverse
+    groupings_list = []
+    for k in result_map.keys(): groupings_list.append(result_map[k])
+    groupings_list_sorted = sorted(groupings_list, key=len)
+    groupings_list_sorted.reverse()
+
+    # return flattened list
+    return [item for sublist in groupings_list_sorted for item in sublist]
 
 # mark an input as reviewed
 def mark_reviewed(input_id):


### PR DESCRIPTION
Utilizes the fuzzywuzzy Python library for fuzzy string matching. Summary of the sorting algorithm:

`let C = map of similar-matching string lists`
`for every record in the database:`
&nbsp;&nbsp;&nbsp;`let L = most relevant line in record script field to fuzzy match`
&nbsp;&nbsp;&nbsp;`for every collection of lists in C:`
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`for every ratio threshold from 90 to 50 counting down by 10:`
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`let R = [] to hold fuzzy-matching ratios`
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`for every entry in collection:`
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`add ratio of fuzzy match between L and entry to R`
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`if average of R > ratio threshold:`
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`add L to collection`

Collection of lists is then sorted in descending order of collection size and flattened before being returned to the template. This whole thing runs every time the /review route is reached and does not cache results, so it needs to be recomputed each time, which is highly inefficient.

Requires

`pip install fuzzywuzzy`

to work, and

`pip install python-Levenshtein`

to work faster.

The process is slow (~60 seconds) by the nature of string-matching hundreds of entries against each other to sort them into buckets each time we query the database. This is many times faster than it was before (> 10 minutes), when the algorithm was to compare full script fields against full script fields, but that is less helpful because of the redundancy of "clang" lines and the last two lines of each script more generally, which skew the data for fuzzy pattern matching, given they are almost always very similar, hence the refining to just lines[1] or lines[0]. 

Curious to hear what might be best in terms of optimizing this so it takes less time than a minute. At first, I thought it might be possible to cache results some way, but it still needs to get a fuzzy ratio for every string in the database per record no matter what, so I'm not sure that would help in any way.
