### PR TITLE
Valgrind matchers

### DIFF
--- a/helpers/valgrind.py
+++ b/helpers/valgrind.py
@@ -10,7 +10,7 @@ def help(lines):
             "Looks like your program leaked {} bytes of memory.".format(matches.group(1)),
             "Did you forget to `free` memory that you allocated using `malloc`?"
         ]
-        return (lines[0:1], valgrind_response(response))
+        return (lines[0:1], valgrind_response(response, lines))
 
     # use of uninitialized value of size 8
     matches = re.search(r"Use of uninitialised value of size (\d+)", lines[0])
@@ -18,7 +18,7 @@ def help(lines):
         response = [
             "Looks like you're trying to access a variable that you might not have assigned a value.",
         ]
-        return (lines[0:1], valgrind_response(response, lines[1:]))
+        return (lines[0:1], valgrind_response(response, lines, issue_lines=lines[1:]))
 
     # invalid write of size 4
     matches = re.search(r"Invalid write of size (\d+)", lines[0])
@@ -27,7 +27,16 @@ def help(lines):
             "Looks like you tried to store {} bytes of data in memory you weren't allowed to access.".format(matches.group(1)),
             "Did you try to store data beyond the bounds of an array?"
         ]
-        return (lines[0:1], valgrind_response(response, lines[1:])))
+        return (lines[0:1], valgrind_response(response, lines, issue_lines=lines[1:]))
+
+    # 40 bytes in 1 blocks are definitely lost in loss record 1 of 1
+    matches = re.search(r"(\d+) bytes in (\d+) blocks are definitely lost in loss record (\d+) of (\d+)", lines[0])
+    if matches:
+        response = [
+            "Looks like your program leaked {} bytes of memory.".format(matches.group(1)),
+            "Did you forget to `free` memory that you allocated using `malloc`?"
+        ]
+        return (lines[0:1], valgrind_response(response, lines, issue_lines=lines[1:]))
 
 
 # finds the function, file, and line of a Valgrind error
@@ -64,7 +73,7 @@ def issue_locate(lines):
 # If `issue_lines` is set, where `issue_lines` are lines of valgrind output,
 #  will search for a line number to pay attention to.
 # If valgrind recommended --leak-check=full, then will append a recommendation.
-def valgrind_response(response, issue_lines=None):
+def valgrind_response(response, lines, issue_lines=None):
     # see if we can identify a line number to highlight
     if issue_lines:
         issue = issue_locate(issue_lines)
@@ -72,7 +81,7 @@ def valgrind_response(response, issue_lines=None):
             response.append("Pay attention to line {} of `{}`.".format(issue.line, issue.file))
 
     # search for --leak-check=full recommendation
-    for line in response:
+    for line in lines:
         if "Rerun with --leak-check=full to see details of leaked memory" in line:
             response.append("Re-run `valgrind` with `--leak-check=full` for more details.")
             break

--- a/helpers/valgrind.py
+++ b/helpers/valgrind.py
@@ -23,6 +23,16 @@ def help(lines):
             response.append("Pay attention to line {} of `{}`.".format(issue.line, issue.file))
         return (lines[0:1], response)
 
+    # invalid write of size 4
+    matches = re.search(r"Invalid write of size (\d+)", lines[0])
+    if matches:
+        response = [
+            "Looks like you tried to store {} bytes of data in memory you weren't allowed to access.".format(matches.group(1)),
+            "Did you try to store data beyond the bounds of an array?"
+        ]
+        return (lines[0:1], response)
+
+
 # finds the function, file, and line of a Valgrind error
 def issue_locate(lines):
     locations = []


### PR DESCRIPTION
Handling issues #199, #200, and #201 

Created a helper function for our `valgrind` matchers just called `valgrind_response`, to take care of the last two lines of `response`:
- In most cases, we'll want a line that suggests a filename and line number. So if `valgrind_response` can find a line number that it thinks is the issue, it'll append a line directing the student there. (This isn't always the case, for example, the leak summary's `"definitely lost"` message doesn't give us any line number indication, which is why I made this an optional parameter).
- If `valgrind_response` detects the `"Rerun with --leak-check=full` message, it'll append that suggestion to `response` as well.