### PR TITLE
No valgrind error matcher

### DIFF
--- a/helpers/valgrind.py
+++ b/helpers/valgrind.py
@@ -90,18 +90,15 @@ def help(lines):
             if matches:
                 response.append("Run `valgrind --leak-check=full {}` for more details.".format(matches.group(1)))
             return (lines[i:i+1], response)
-        
+
         # All heap blocks were freed -- no leaks are possible
         # ERROR SUMMARY: 0 errors from 0 contexts
-        matches = re.search(r"==\d+== All heap blocks were freed -- no leaks are possible", line)
-        if matches:
-            remaining_lines = lines[i+1:]
-            for line in remaining_lines:
-                if re.search(r"==\d+== ERROR SUMMARY: 0 errors from 0 contexts", line):
-                    response = [
-                        "Looks like your program doesn't have any memory errors!"
-                    ]
-                    return (lines[i:i+1], response)
+        if re.search(r"^==\d+== All heap blocks were freed -- no leaks are possible$", line):
+            if re.search(r"^==\d+== ERROR SUMMARY: 0 errors from 0 contexts", "\n".join(lines[i+1:]), re.MULTILINE):
+                response = [
+                    "Looks like your program doesn't have any memory-related errors!"
+                ]
+                return (lines[i:i+1], response)
 
 # finds the function, file, and line of an issue
 def issue_locate(lines):

--- a/helpers/valgrind.py
+++ b/helpers/valgrind.py
@@ -91,7 +91,8 @@ def help(lines):
                 response.append("Run `valgrind --leak-check=full {}` for more details.".format(matches.group(1)))
             return (lines[i:i+1], response)
         
-        # No errors
+        # All heap blocks were freed -- no leaks are possible
+        # ERROR SUMMARY: 0 errors from 0 contexts
         matches = re.search(r"==\d+== All heap blocks were freed -- no leaks are possible", line)
         if matches:
             remaining_lines = lines[i+1:]

--- a/helpers/valgrind.py
+++ b/helpers/valgrind.py
@@ -90,6 +90,17 @@ def help(lines):
             if matches:
                 response.append("Run `valgrind --leak-check=full {}` for more details.".format(matches.group(1)))
             return (lines[i:i+1], response)
+        
+        # No errors
+        matches = re.search(r"==\d+== All heap blocks were freed -- no leaks are possible", line)
+        if matches:
+            remaining_lines = lines[i+1:]
+            for line in remaining_lines:
+                if re.search(r"==\d+== ERROR SUMMARY: 0 errors from 0 contexts", line):
+                    response = [
+                        "Looks like your program doesn't have any memory errors!"
+                    ]
+                    return (lines[i:i+1], response)
 
 # finds the function, file, and line of an issue
 def issue_locate(lines):


### PR DESCRIPTION
In the same way that we have a matcher when `make` produces no errors, probably a good idea to have one for `valgrind`. In this case, we say there are no errors when we see both:

```
All heap blocks were freed -- no leaks are possible
```

and

```
ERROR SUMMARY: 0 errors from 0 contexts
```


Sample valgrind output:

```
==8877== Memcheck, a memory error detector
==8877== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==8877== Using Valgrind-3.10.1 and LibVEX; rerun with -h for copyright info
==8877== Command: ./test2
==8877== 
==8877== 
==8877== HEAP SUMMARY:
==8877==     in use at exit: 0 bytes in 0 blocks
==8877==   total heap usage: 1 allocs, 1 frees, 40 bytes allocated
==8877== 
==8877== All heap blocks were freed -- no leaks are possible
==8877== 
==8877== For counts of detected and suppressed errors, rerun with: -v
==8877== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```