### PR TITLE
Fix out-of-bounds error on valgrind matcher

### DIFF
--- a/helpers/valgrind.py
+++ b/helpers/valgrind.py
@@ -98,7 +98,7 @@ def help(lines):
         # All heap blocks were freed -- no leaks are possible
         # ERROR SUMMARY: 0 errors from 0 contexts
         if re.search(r"^==\d+== All heap blocks were freed -- no leaks are possible$", line):
-            for j in range(i+1, len(lines)+1):
+            for j in range(i+1, len(lines)):
                 if re.search(r"^==\d+== ERROR SUMMARY: 0 errors from 0 contexts", lines[j]):
                     response = [
                         "Looks like your program doesn't have any memory-related errors!"


### PR DESCRIPTION
Addressing sysadmins reported issue 7946.

The current `valgrind` matcher fails whenever `all heap blocks are freed` but there are other errors, because it's searching for the line that says `0 errors from 0 contexts` and it searches one past the last line. Modified to stop searching after it hits the last line.