### PR TITLE
Don't match on leak of 0 bytes.

### DIFF
--- a/helpers/valgrind.py
+++ b/helpers/valgrind.py
@@ -84,7 +84,7 @@ def help(lines):
 
         # definitely lost: 4 bytes in 1 blocks
         matches = re.search(r"^==\d+==    definitely lost: ([\d,]+) bytes in ([\d,]+) blocks$", line)
-        if matches:
+        if matches and locale.atoi(matches.group(1)) != 0:
             bytes = "bytes" if locale.atoi(matches.group(1)) > 1 else "byte"
             response = [
                 "Looks like your program leaked {} {} of memory.".format(matches.group(1), bytes),


### PR DESCRIPTION
As pointed out to me by @annieechen, if there are no definitely lost bytes, but are still memory errors of other types reported by `valgrind`, `help50` produces help like this:

```
Looks like your program leaked 0 byte of memory. Did you forget to `free` memory that you allocated via `malloc`?
```

Adjusted the matcher to guarantee that we actually `definitely lost` something before providing a response.